### PR TITLE
Add option to not duplicate links in explicit builder

### DIFF
--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from edgegraph.structure import Vertex, DirectedEdge, UnDirectedEdge
 
-def link_from_to(v1: Vertex, lnktype: type, v2: Vertex):
+def link_from_to(v1: Vertex, lnktype: type, v2: Vertex, dontdup: bool=False):
     """
     Create a link of type ``lnktype`` from ``v1`` to ``v2``.
 
@@ -36,12 +36,22 @@ def link_from_to(v1: Vertex, lnktype: type, v2: Vertex):
     :param v1: One end of the link.
     :param lnktype: The class of the link.
     :param v2: The other end of the link.
+    :param dontdup: If set to True, performs a check for any already-existing
+      links between v1 and v2.  If any are found (of any type, directed or
+      undirected), no new link is created, but the already-existing one is
+      returned silently.
     :return: The link instance.
     :rtype: An instance of the param ``lnktype``.
     """
+
+    if dontdup:
+        for lnk in v1.links:
+            if lnk.other(v1) is v2:
+                return lnk
+
     return lnktype(v1, v2)
 
-def link_directed(v1: Vertex, v2: Vertex) -> DirectedEdge:
+def link_directed(v1: Vertex, v2: Vertex, dontdup: bool=False) -> DirectedEdge:
     """
     Create a :py:class:`~edgegraph.structure.directededge.DirectedEdge` between
     the two vertices.
@@ -71,9 +81,9 @@ def link_directed(v1: Vertex, v2: Vertex) -> DirectedEdge:
     :param v2: The destination end of the link.
     :return: The link that was created.
     """
-    return link_from_to(v1, DirectedEdge, v2)
+    return link_from_to(v1, DirectedEdge, v2, dontdup=dontdup)
 
-def link_undirected(v1: Vertex, v2: Vertex) -> UnDirectedEdge:
+def link_undirected(v1: Vertex, v2: Vertex, dontdup: bool=False) -> UnDirectedEdge:
     """
     Create a :py:class:`~edgegraph.structure.undirectededge.UnDirectedEdge`
     between the two vertices.
@@ -98,5 +108,5 @@ def link_undirected(v1: Vertex, v2: Vertex) -> UnDirectedEdge:
     :param v2: The other end of the link.
     :return: The link that was created.
     """
-    return link_from_to(v1, UnDirectedEdge, v2)
+    return link_from_to(v1, UnDirectedEdge, v2, dontdup=dontdup)
 

--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -79,6 +79,10 @@ def link_directed(v1: Vertex, v2: Vertex, dontdup: bool=False) -> DirectedEdge:
 
     :param v1: The origin end of the link.
     :param v2: The destination end of the link.
+    :param dontdup: If set to True, performs a check for any already-existing
+      links between v1 and v2.  If any are found (of any type, directed or
+      undirected), no new link is created, but the already-existing one is
+      returned silently.
     :return: The link that was created.
     """
     return link_from_to(v1, DirectedEdge, v2, dontdup=dontdup)
@@ -106,6 +110,10 @@ def link_undirected(v1: Vertex, v2: Vertex, dontdup: bool=False) -> UnDirectedEd
 
     :param v1: One end of the link.
     :param v2: The other end of the link.
+    :param dontdup: If set to True, performs a check for any already-existing
+      links between v1 and v2.  If any are found (of any type, directed or
+      undirected), no new link is created, but the already-existing one is
+      returned silently.
     :return: The link that was created.
     """
     return link_from_to(v1, UnDirectedEdge, v2, dontdup=dontdup)

--- a/tests/builder/test_explicit.py
+++ b/tests/builder/test_explicit.py
@@ -101,3 +101,38 @@ def test_link_basecls_chain():
     assert l2.vertices == (verts[1], verts[2]), "l2 has wrong vertices"
     assert l3.vertices == (verts[2], verts[3]), "l3 has wrong vertices"
 
+def test_dontdup():
+    """
+    Ensure the dontdup argument works as intended.
+    """
+
+    verts = [Vertex(), Vertex(), Vertex(), Vertex()]
+
+    # first up -- test with link_from_to
+    l1 = explicit.link_from_to(verts[0], TwoEndedLink, verts[1])
+    assert len(verts[0].links) == 1, "starting condition incorrect"
+    l2 = explicit.link_from_to(verts[0], TwoEndedLink, verts[1], dontdup=True)
+    assert len(verts[1].links) == 1, "created a duplicate link"
+    assert l1 is l2, "got back something other than preexisting link"
+
+    # next, link_directed, to ensure argument passthru is working
+    l3 = explicit.link_directed(verts[1], verts[2])
+    assert verts[1].links == (l1, l3), "starting condition incorrect"
+    l4 = explicit.link_directed(verts[1], verts[2], dontdup=True)
+    assert verts[1].links == (l1, l3), "created a duplicate link"
+    assert l3 is l4, "got back something other than preexisting link"
+
+    # link_undirected, to (again) ensure arg passthru
+    l5 = explicit.link_undirected(verts[2], verts[3])
+    assert verts[2].links == (l3, l5), "starting conditions incorrect"
+    l6 = explicit.link_undirected(verts[2], verts[3], dontdup=True)
+    assert verts[2].links == (l3, l5), "created a duplicate link"
+    assert l5 is l6, "got back something other than preexisting link"
+
+    # check that we can duplicate a link after a dontdup call
+    l7 = explicit.link_from_to(verts[0], TwoEndedLink, verts[1])
+    assert verts[0].links == (l1, l7), "did not add post-dontdup link!"
+    # and finally, check it still makes a new link if there is no duplicate
+    l8 = explicit.link_from_to(verts[0], TwoEndedLink, verts[3], dontdup=True)
+    assert verts[0].links == (l1, l7, l8), "did not add post-dontdup link!"
+


### PR DESCRIPTION
Adds `dontdup` optional argument to `builder.explicit` functions.  If set, this will check for existing links between the given vertices.  If any already exist, a new link is *not* created.