### PR TITLE
Improve traversal.helpers

### DIFF
--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -191,3 +191,55 @@ def neighbors(vert: Vertex,
 
     return nbs
 
+def find_links(v1, v2,
+        direction_sensitive: bool=True,
+        unknown_handling: int=LNK_UNKNOWN_ERROR,
+        filterfunc: Callable=None):
+    """
+    Find links that connect v1 to v2.
+    """
+
+    links = set()
+    for link in v1.links:
+
+        # no matter what the other options are, don't care!
+        if link.other(v1) is not v2:
+            continue
+
+        if direction_sensitive:
+
+            if issubclass(type(link), UnDirectedEdge):
+
+                if filterfunc is None or filterfunc(link):
+                    links.add(link)
+                else:
+                    continue  # pragma: no cover
+
+            elif issubclass(type(link), DirectedEdge):
+
+                if link.v1 is not v1:
+                    # this is a link from v2 to v1, not the way we want
+                    continue
+
+                if filterfunc is None or filterfunc(link):
+                    links.add(link)
+                else:
+                    continue  # pragma: no cover
+
+            else:
+                if unknown_handling == LNK_UNKNOWN_NONNEIGHBOR:
+                    continue
+
+                if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
+                    links.add(link)
+                else:
+                    raise NotImplementedError(f"Unknown link class {type(link)}")
+
+        else:
+            # see above notes on short-circuiting filterfunc() if it's not
+            # provided
+            if filterfunc is None or filterfunc(link):
+                links.add(link)
+
+    return links
+

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -33,6 +33,7 @@ LNK_UNKNOWN_ERROR = 2
 def neighbors(vert: Vertex,
         direction_sensitive: bool=True,
         unknown_handling: int=LNK_UNKNOWN_ERROR,
+        filterfunc: Callable=None,
         ) -> list[Vertex]:
     """
     Identify the neighbors of a given vertex.
@@ -84,6 +85,8 @@ def neighbors(vert: Vertex,
        as non-neighbors, :py:const:`LNK_UNKNOWN_NEIGHBOR` to treat unknown
        edges *as* neighbors, or :py:const:`LNK_UNKNOWN_ERROR` to raise a
        :py:exc:`NotImplementedError` if such an edge is encountered.
+    :param filterfunc: Callable object to determine whether the given edge /
+       vertex should be included in the neighbors output.
     :raises NotImplementedError: if kwarg ``unknown_handling`` is set to
        :py:const:`LNK_UNKNOWN_ERROR` and an unknown edge class is enountered.
     :return: A list of :py:class:`~edgegraph.structure.vertex.Vertex` objects
@@ -93,14 +96,46 @@ def neighbors(vert: Vertex,
     nbs = []
     for link in vert.links:
 
+        v2 = link.other(vert)
+
         if direction_sensitive:
             # undirected edges don't matter
             if issubclass(type(link), UnDirectedEdge):
-                nbs.append(link.other(vert))
+
+                # we'll use boolean short-circuiting to prevent an unnecessary
+                # call into a default filterfunc if one is not provided.  such
+                # a default would always return True, but be an unnecessary
+                # call context switch.
+                # so, we'll first check if filterfunc is None -- if so, good
+                # enough, we can add this to the neighbors.  otherwise, it was
+                # in fact specified, and we should check its decision.
+                # this goes for all three places filterfunc() is used in this
+                # neighbors function
+                if filterfunc is None or filterfunc(link, v2):
+                    nbs.append(v2)
+                else:
+
+                    # this is not detectable by coverage.py, due to a ~~bug~~
+                    # side effect of the python peephole optimizer.  continue
+                    # statements inside else: blocks are often skipped /
+                    # replaced with a jump opcode.  see
+                    # https://github.com/nedbat/coveragepy/issues/198#issuecomment-399705984
+                    # for more info.  for proof that this IS run, uncomment:
+                    # raise Exception("look, ma!  this happened!")
+                    # and re-run unit tests.  You'll get that exception.
+                    continue  # pragma: no cover
 
             # for directed edges, only add the neighbor if vert is the origin
             elif issubclass(type(link), DirectedEdge) and (link.v1 is vert):
-                nbs.append(link.other(vert))
+
+                # see above notes on short-circuiting filterfunc() if it's not
+                # provided
+                if filterfunc is None or filterfunc(link, v2):
+                    nbs.append(v2)
+                else:
+                    # see comment on the above else: continue block for
+                    # explanation of this no-cover statement.
+                    continue  # pragma: no cover
 
             # we're looking at v2 -- the destination
             # TODO: is it more time efficient to move the v1/v2 comparison into
@@ -118,7 +153,10 @@ def neighbors(vert: Vertex,
                     raise NotImplementedError(f"Unknown link class {type(link)}")
 
         else:
-            nbs.append(link.other(vert))
+            # see above notes on short-circuiting filterfunc() if it's not
+            # provided
+            if filterfunc is None or filterfunc(link, v2):
+                nbs.append(v2)
 
     return nbs
 

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -62,14 +62,45 @@ def neighbors(vert: Vertex,
 
     the function would operate as:
 
-       >>> neighbors(v1)
-       [v2, v3]
-       >>> neighbors(v1, direction_sensitive=False)
-       [v2, v3, v4]
-       >>> neighbors(v4)
-       [v1]
-       >>> neighbors(v4, direction_sensitive=False)
-       [v1, v3]
+    >>> neighbors(v1)
+    [v2, v3]
+    >>> neighbors(v1, direction_sensitive=False)
+    [v2, v3, v4]
+    >>> neighbors(v4)
+    [v1]
+    >>> neighbors(v4, direction_sensitive=False)
+    [v1, v3]
+
+    If supplied, the ``filterfunc`` argument should be to a callable object
+    (function or otherwise) that will return either :py:obj:`True` or
+    :py:obj:`False`.  This function is used to determine if a given vertex
+    should be included in the returned neighbors.  It must have the following
+    signature:
+
+    .. py:function:: filterfunc(e, v2)
+       :noindex:
+
+       Determines if a given vertex (``v2``) should be included in the
+       neighbors of ``v``.  Because ``v2`` may be reachable from ``v1`` via
+       multiple edges, the edge currently being considered is given as well.
+
+       :param e: The edge connecting ``v1`` to ``v2``.
+       :param v2: The vertex under consideration.
+       :return: Whether or not ``v2`` should be considered a neighbor of ``v``,
+          when reached via ``e``.
+
+    For example, one may wish to only consider vertices if a given attribute
+    meets some criteria:
+
+    >>> neighbors(v1)
+    [v2, v3]
+    >>> neighbors(v1, filterfunc=lambda e, v2: v2.i >= 3)
+    [v3]
+
+    .. note::
+
+       The ``filterfunc`` parameter operates **in addition to** the
+       ``direction_sensitive`` parameter!
 
     :param vert: The vertex to identify neighbors of.
     :param direction_sensitive: Enables handling of directional links.  If set

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -90,3 +90,109 @@ def test_neighbors_unknown_link_type():
     assert v0nb1 == [v[1]], "LNK_UNKNOWN_NEIGHBOR behavior wrong!"
     assert v0nb2 == [], "LNK_UNKNOWN_NONNEIGHBOR behavior wrong!"
 
+def test_neighbors_filter_func_subclass_directededge():
+    """
+    Ensure the neighbors function filterfunc works in a vertex application.
+    """
+    class VT1(Vertex):
+        pass
+    class VT2(VT1):
+        pass
+
+    #       0         1        2      3      4     5
+    v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
+    adj = {
+            v[0]: [v[1], v[2], v[4]],
+            v[2]: [v[0], v[3], v[4]],
+            v[4]: [v[0], v[2], v[5]],
+        }
+    adjlist.load_adj_dict(adj, DirectedEdge)
+
+    def filterfunc(e, v2):
+        return isinstance(v2, VT1)
+
+    nb1 = set(helpers.neighbors(v[0], filterfunc=filterfunc))
+    assert nb1 == {v[2], v[4]}, "Neighbors filterfunc gave wrong answer"
+
+    nb2 = set(helpers.neighbors(v[2], filterfunc=filterfunc))
+    assert nb2 == {v[3], v[4]}, "Neighbors filterfunc gave wrong answer"
+
+    nb3 = set(helpers.neighbors(v[4], filterfunc=filterfunc))
+    assert nb3 == {v[2], v[5]}, "Neighbors filterfunc gave wrong answer"
+
+def test_neighbors_filter_func_subclass_nondirected():
+    """
+    Ensure the neighbors function filterfunc works in a vertex and direction
+    non-sensitive application.
+    """
+    class VT1(Vertex):
+        pass
+    class VT2(VT1):
+        pass
+
+    #       0         1        2      3      4     5
+    v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
+    adj = {
+            v[0]: [v[1], v[2], v[4]],
+            v[1]: [v[0], v[2], v[4]],
+            v[2]: [v[0], v[3], v[4]],
+            v[3]: [v[0], v[2], v[4]],
+            v[4]: [v[0], v[2], v[5]],
+            v[5]: [v[0], v[2], v[4]],
+        }
+    adjlist.load_adj_dict(adj, DirectedEdge)
+
+    def filterfunc(e, v2):
+        return isinstance(v2, VT1)
+
+    nb1 = set(helpers.neighbors(v[0], direction_sensitive=False,
+        filterfunc=filterfunc))
+    assert nb1 == {v[2], v[3], v[4], v[5]}, \
+            "Neighbors filterfunc gave wrong answer"
+
+    nb2 = set(helpers.neighbors(v[2], direction_sensitive=False,
+        filterfunc=filterfunc))
+    assert nb2 == {v[3], v[4], v[5]}, "Neighbors filterfunc gave wrong answer"
+
+    nb3 = set(helpers.neighbors(v[4], direction_sensitive=False,
+        filterfunc=filterfunc))
+    assert nb3 == {v[2], v[3], v[5]}, "Neighbors filterfunc gave wrong answer"
+
+def test_neighbors_filter_func_subclass_undirected():
+    """
+    Ensure the neighbors function filterfunc works in a vertex and
+    undirectededge application.
+    """
+    class VT1(Vertex):
+        pass
+    class VT2(VT1):
+        pass
+
+    #       0         1        2      3      4     5
+    v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
+    adj = {
+            v[0]: [v[1], v[2], v[4]],
+            v[1]: [v[0], v[2], v[4]],
+            v[2]: [v[0], v[3], v[4]],
+            v[3]: [v[0], v[2], v[4]],
+            v[4]: [v[0], v[2], v[5]],
+            v[5]: [v[0], v[2], v[4]],
+        }
+    adjlist.load_adj_dict(adj, UnDirectedEdge)
+
+    def filterfunc(e, v2):
+        return isinstance(v2, VT1)
+
+    nb1 = set(helpers.neighbors(v[0], direction_sensitive=True,
+        filterfunc=filterfunc))
+    assert nb1 == {v[2], v[3], v[4], v[5]}, \
+            "Neighbors filterfunc gave wrong answer"
+
+    nb2 = set(helpers.neighbors(v[2], direction_sensitive=True,
+        filterfunc=filterfunc))
+    assert nb2 == {v[3], v[4], v[5]}, "Neighbors filterfunc gave wrong answer"
+
+    nb3 = set(helpers.neighbors(v[4], direction_sensitive=True,
+        filterfunc=filterfunc))
+    assert nb3 == {v[2], v[3], v[5]}, "Neighbors filterfunc gave wrong answer"
+

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -232,9 +232,9 @@ def test_findlinks_no_links():
     assert t1 == set(), "find_links returned when there are no links!"
 
     t2 = helpers.find_links(v1, v2, direction_sensitive=False)
-    assert t1 == set(), "find_links returned when there are no links!"
+    assert t2 == set(), "find_links returned when there are no links!"
 
-    e1 = explicit.link_directed(v2, v1)
+    explicit.link_directed(v2, v1)
     t3 = helpers.find_links(v1, v2)
     assert t3 == set(), "find_links returned when no outbound links!"
 
@@ -334,16 +334,16 @@ def test_findlinks_stress(n_links):
     for _ in range(n_links):
         edges.append(explicit.link_directed(v1, v2))
 
-    N = 2500
+    iters = 2500
 
     t_start = time.monotonic_ns()
-    for _ in range(N):
+    for _ in range(iters):
         helpers.find_links(v1, v2)
     t_end = time.monotonic_ns()
 
     # analysis
     t_diff = t_end - t_start
-    t_per = t_diff / N
+    t_per = t_diff / iters
 
     # convert to seconds
     t_diff /= 1_000_000_000

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -17,7 +17,13 @@ from edgegraph.builder import adjlist, explicit
 # however, the caes it wants to correct in here are like ``assert nb == []``,
 # which, in the context of the text, expresses intent much more clearly than
 # ``assert not nb``.  so, shut up!
-# pylint: disable=C1803
+# C0115 is missing-class-docstring
+# happens where we want to subclass Vertex or TwoEndedLink or something.  for
+# test applications, full class docstrings aren't necessary
+# W0613 is unused-argument
+# test parameters for filterfunc()'s.  for testing purposes, some parameters
+# are ignored.
+# pylint: disable=C1803, C0115, W0613
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Adds some utility to `edgegraph.traversal.helpers`:

* New function, `find_links(v1, v2)` to identify edges that connect v1 and v2
* Adds `filterfunc` option to both `neighbors` and `find_links` to perform inline filtering of output