### PR TITLE
Bugfix/vertex uni autoreg

### DIFF
--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -34,6 +34,9 @@ class Vertex(base.BaseObject):
         """
         Creates a new vertex.
 
+        Unlike BaseObject, the Vertex class will add itself to Universes
+        provided to this method.
+
         :param links: iterable of link objects to associate this vertex with
 
         .. seealso::
@@ -53,6 +56,10 @@ class Vertex(base.BaseObject):
         if links is not None:
             for link in links:
                 self.add_to_link(link)
+
+        # ensure that we add ourselves to the universes given
+        for uni in self.universes:
+            uni.add_vertex(self)
 
     def add_to_universe(self, universe: Universe) -> None:
         """

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -73,7 +73,7 @@ def bfs(uni: Universe, start: Vertex, attrib: str, val: object) -> Vertex:
     :param val: The value to check for in the aforementioned attribute.
     :return: The vertex which first matched the specified attribute value.
     """
-    if len(uni.vertices) == 0:
+    if (uni is not None) and (len(uni.vertices) == 0):
         # empty!
         return None
     if (uni is not None) and (start not in uni.vertices):
@@ -117,7 +117,7 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
     :param start: The vertex to start searching at.
     :return: The vertices visited during traversal.
     """
-    if len(uni.vertices) == 0:
+    if (uni is not None) and (len(uni.vertices) == 0):
         # empty!
         return None
     if (uni is not None) and (start not in uni.vertices):

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -79,6 +79,10 @@ def bfs(uni: Universe, start: Vertex, attrib: str, val: object) -> Vertex:
     if (uni is not None) and (start not in uni.vertices):
         raise ValueError("Start vertex not in specified universe!")
 
+    if hasattr(start, attrib):
+        if start[attrib] == val:
+            return start
+
     visited = set()
     queue = collections.deque([start])
     visited.add(start)

--- a/edgegraph/traversal/depthfirst.py
+++ b/edgegraph/traversal/depthfirst.py
@@ -66,7 +66,7 @@ def _df_preflight_checks(uni: Universe, start: Vertex):
     :raises ValueError: if the universe is empty, or if the start vertex is not
        in the given universe.
     """
-    if len(uni.vertices) == 0:
+    if (uni is not None) and (len(uni.vertices) == 0):
         raise ValueError("Universe is empty; cannot perform this operation!")
     if (uni is not None) and (start not in uni.vertices):
         raise ValueError("Start vertex not in specified universe!")

--- a/tests/structure/test_vertex.py
+++ b/tests/structure/test_vertex.py
@@ -119,3 +119,28 @@ def test_vert_add_to_uni():
     assert len(v.universes) == 50, "vertex .universes has wrong # elements!"
     for uni in unis:
         assert v in uni.vertices, "vertex add_to_universe did not back-ref!"
+
+
+def test_vert_init_with_uni():
+    """
+    Ensure vertices init'd with universes are members of them.
+    """
+    unis = []
+    for _ in range(50):
+        unis.append(universe.Universe())
+
+    v1 = vertex.Vertex(universes=[unis[0]])
+
+    assert v1.universes == set(
+        [unis[0]]
+    ), "vertex .universes does not match what was given to init!"
+    assert v1 in unis[0].vertices, "vertex did not register itself in universe!"
+
+    v2 = vertex.Vertex(universes=unis)
+    assert v2.universes == set(
+        unis
+    ), "vertex .universes does not match what was given to init!"
+    for uni in unis:
+        assert (
+            v2 in uni.vertices
+        ), "vertex did not register itself in universes!"

--- a/tests/traversal/test_breadthfirst.py
+++ b/tests/traversal/test_breadthfirst.py
@@ -91,7 +91,7 @@ def test_bfs_none_universe(graph_clrs09_22_6):
     """
     Ensure BFS works with universe = None.
     """
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
     search = breadthfirst.bfs(None, verts[0], "i", 7)
     assert search is verts[7], "BFS did not find answer when uni=None!"
 
@@ -164,7 +164,7 @@ def test_bft_none_universe(graph_clrs09_22_6):
     """
     Ensure BFT works when universe = None.
     """
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
     trav = breadthfirst.bft(None, verts[0])
     trav = [v.i for v in trav]
     assert trav == [

--- a/tests/traversal/test_breadthfirst.py
+++ b/tests/traversal/test_breadthfirst.py
@@ -96,6 +96,16 @@ def test_bfs_none_universe(graph_clrs09_22_6):
     assert search is verts[7], "BFS did not find answer when uni=None!"
 
 
+def test_bfs_finds_first_vertex(graph_clrs09_22_6):
+    """
+    Ensure BFS finds the starting vertex, if that's what it's given.
+    """
+    uni, verts = graph_clrs09_22_6
+    for vert in verts:
+        search = breadthfirst.bfs(uni, vert, "i", vert.i)
+        assert search is vert, f"BFS did not identify the starting vertex!"
+
+
 ###############################################################################
 # traversal!
 

--- a/tests/traversal/test_breadthfirst.py
+++ b/tests/traversal/test_breadthfirst.py
@@ -87,6 +87,15 @@ def test_bfs_search_wrong_attr(graph_clrs09_22_6):
     assert right is verts[6], "BFS did not find right answer!"
 
 
+def test_bfs_none_universe(graph_clrs09_22_6):
+    """
+    Ensure BFS works with universe = None.
+    """
+    uni, verts = graph_clrs09_22_6
+    search = breadthfirst.bfs(None, verts[0], "i", 7)
+    assert search is verts[7], "BFS did not find answer when uni=None!"
+
+
 ###############################################################################
 # traversal!
 
@@ -149,6 +158,25 @@ def test_bft_trav_out_of_uni(graph_clrs09_22_6):
     trav = breadthfirst.bft(uni, verts[0])
     vals = [v.i for v in trav]
     assert -1 not in vals, "BFT found an out-of-universe vert!"
+
+
+def test_bft_none_universe(graph_clrs09_22_6):
+    """
+    Ensure BFT works when universe = None.
+    """
+    uni, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(None, verts[0])
+    trav = [v.i for v in trav]
+    assert trav == [
+        0,
+        2,
+        3,
+        6,
+        5,
+        7,
+        8,
+        9,
+    ], "BFT did not traverse when uni = None!"
 
 
 ###############################################################################

--- a/tests/traversal/test_depthfirst.py
+++ b/tests/traversal/test_depthfirst.py
@@ -135,7 +135,7 @@ def test_dfti_none_universe(graph_clrs09_22_6):
     """
     Ensure DFTI work when universe = None.
     """
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
     trav = depthfirst.dft_iterative(None, verts[0])
     trav = [v.i for v in trav]
     assert trav == dfti_data[0][1], "DFTI did not traverse with uni = None"
@@ -145,7 +145,7 @@ def test_dftr_none_universe(graph_clrs09_22_6):
     """
     Ensure DFTR work when universe = None.
     """
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
     trav = depthfirst.dft_recursive(None, verts[0])
     trav = [v.i for v in trav]
     assert trav == dftr_data[0][1], "DFTR did not traverse with uni = None"
@@ -250,7 +250,7 @@ def test_dfs_none_universe(graph_clrs09_22_6, func):
     """
     Ensure DFS works when universe = None.
     """
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
     vert = func(None, verts[0], "i", 8)
     assert vert is verts[8], f"{func} did not find answer with uni = None!"
 

--- a/tests/traversal/test_depthfirst.py
+++ b/tests/traversal/test_depthfirst.py
@@ -131,6 +131,26 @@ def test_dft_deterministic(graph_clrs09_22_6, func):
         assert ans == prev, "dft_recursive is not deterministic!"
 
 
+def test_dfti_none_universe(graph_clrs09_22_6):
+    """
+    Ensure DFTI work when universe = None.
+    """
+    uni, verts = graph_clrs09_22_6
+    trav = depthfirst.dft_iterative(None, verts[0])
+    trav = [v.i for v in trav]
+    assert trav == dfti_data[0][1], "DFTI did not traverse with uni = None"
+
+
+def test_dftr_none_universe(graph_clrs09_22_6):
+    """
+    Ensure DFTR work when universe = None.
+    """
+    uni, verts = graph_clrs09_22_6
+    trav = depthfirst.dft_recursive(None, verts[0])
+    trav = [v.i for v in trav]
+    assert trav == dftr_data[0][1], "DFTR did not traverse with uni = None"
+
+
 ###############################################################################
 # searches!
 
@@ -223,6 +243,16 @@ def test_dfs_finds_first_vertex(graph_clrs09_22_6, func):
     for vert in verts:
         search = func(uni, vert, "i", vert.i)
         assert search is vert, f"{func} did not identify the starting vertex!"
+
+
+@pytest.mark.parametrize("func", searches)
+def test_dfs_none_universe(graph_clrs09_22_6, func):
+    """
+    Ensure DFS works when universe = None.
+    """
+    uni, verts = graph_clrs09_22_6
+    vert = func(None, verts[0], "i", 8)
+    assert vert is verts[8], f"{func} did not find answer with uni = None!"
 
 
 ###############################################################################


### PR DESCRIPTION
Fixes three bugs:

- Vertex objects did not automatically register themselves into Universes passed into Vertex.__init__, as was intended.
- All traversal and search functions broke if their universe argument was `None`, despite being designed to work without it (due to an issue in "pre-flight checks").
- Issue #5 