### PR TITLE
Add graph de-construction utilities

### DIFF
--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -62,7 +62,6 @@ def unlink(v1: Vertex, v2: Vertex, destroy=True) -> None:
     vertices ``v1`` and ``v2``.  If the ``destroy`` parameter is set (default),
     then the link objects are also deleted; if not, they are returned in a set.
 
-
     :param v1: One vertex to unlink.
     :param v2: Other vertex to unlink.
     :param destroy: Whether to automatically delete the link objects.

--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -17,6 +17,7 @@ functions will get the necessary updates to match, and the API stays unchanged.
 from __future__ import annotations
 
 from edgegraph.structure import Vertex, DirectedEdge, UnDirectedEdge
+from edgegraph.traversal import helpers
 
 
 def link_from_to(v1: Vertex, lnktype: type, v2: Vertex, dontdup: bool = False):
@@ -51,6 +52,41 @@ def link_from_to(v1: Vertex, lnktype: type, v2: Vertex, dontdup: bool = False):
                 return lnk
 
     return lnktype(v1, v2)
+
+
+def unlink(v1: Vertex, v2: Vertex, destroy=True) -> None:
+    """
+    Remive all links between ``v1`` and ``v2``.
+
+    This function identifies and removes all links that exist between given
+    vertices ``v1`` and ``v2``.  If the ``destroy`` parameter is set (default),
+    then the link objects are also deleted; if not, they are returned in a set.
+
+
+    :param v1: One vertex to unlink.
+    :param v2: Other vertex to unlink.
+    :param destroy: Whether to automatically delete the link objects.
+    :return: None if ``destroy`` is True, otherwise, a set of links that were
+       removed.
+    """
+    links = helpers.find_links(v1, v2, direction_sensitive=False)
+
+    if not destroy:
+        out = set()
+
+    for link in links:
+        link.unlink_from(v1)
+        link.unlink_from(v2)
+
+        if destroy:
+            del link
+        else:
+            out.add(link)
+
+    if not destroy:
+        return out
+    else:
+        return None
 
 
 def link_directed(

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -236,6 +236,19 @@ class Universe(vertex.Vertex):
         if self not in vert.universes:
             vert.add_to_universe(self)
 
+    def remove_vertex(self, vert: vertex.Vertex):
+        """
+        Remove a vertex from this universe.
+
+        The vertex in question will be removed from this universe's record of
+        vertices.
+
+        :param vert: the vertex to be removed
+        """
+        self._vertices.remove(vert)
+        if self in vert.universes:
+            vert.remove_from_universe(self)
+
     @property
     def laws(self) -> UniverseLaws:
         """

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -241,7 +241,8 @@ class Universe(vertex.Vertex):
         Remove a vertex from this universe.
 
         The vertex in question will be removed from this universe's record of
-        vertices.
+        vertices.  If necessary. this universe will then be removed from the
+        vertices' record of universes as well.
 
         :param vert: the vertex to be removed
         """

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -131,4 +131,3 @@ class Vertex(base.BaseObject):
         super().remove_from_universe(universe)
         if self in universe.vertices:
             universe.remove_vertex(self)
-

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -116,3 +116,19 @@ class Vertex(base.BaseObject):
         if link in self._links:
             self._links.remove(link)
             link.unlink_from(self)
+
+    def remove_from_universe(self, universe: Universe) -> None:
+        """
+        Remove this vertex from the specified universe.
+
+        In addition to the superclass method, also removes the vertex from the
+        universe's record of vertices as well as simply removing the universe
+        from this vertices' record of universes if necessary.
+
+        :param universe: the universe that this vertex will be removed from
+        :raises KeyError: if this object is not present in the given universe
+        """
+        super().remove_from_universe(universe)
+        if self in universe.vertices:
+            universe.remove_vertex(self)
+

--- a/tests/builder/test_explicit.py
+++ b/tests/builder/test_explicit.py
@@ -90,6 +90,7 @@ def test_unlink_basic():
     assert len(v1.links) == 0, "unlink did not clean v1.links!"
     assert len(v2.links) == 0, "unlink did not clean v2.links!"
 
+
 def test_unlink_multiple():
     """
     Ensure the unlink() function works on multiple-linked cases.
@@ -144,7 +145,7 @@ def test_unlink_returns_links(graph_clrs09_22_6):
     links = helpers.find_links(x, z, direction_sensitive=False)
 
     undone = explicit.unlink(x, z, destroy=False)
-    
+
     assert undone == links, "unlink() did not return expected links??"
 
 

--- a/tests/builder/test_explicit.py
+++ b/tests/builder/test_explicit.py
@@ -117,6 +117,12 @@ def test_unlink_multiple():
 
 
 def test_unlink_in_situ(graph_clrs09_22_6):
+    """
+    Tests the unlinking logic in a real graph scenario.
+
+    This test ensure that unlinking two nodes in a graph doesn't alter any of
+    the other links around them.
+    """
     _, verts = graph_clrs09_22_6
     q, r, s, t, u, v, w, x, y, z = verts
 
@@ -138,10 +144,36 @@ def test_unlink_in_situ(graph_clrs09_22_6):
     assert len(x.links) == 1, "unlink() did not clean x.links()!"
     assert len(z.links) == 0, "unlink() did not clean z.links()!"
 
+    assert set(helpers.neighbors(q)) == {s, t, w}, "unlink() broke 22.6/q!"
+    assert set(helpers.neighbors(r)) == {
+        y,
+    }, "unlink() broke 22.6/r!"
+    assert set(helpers.neighbors(s)) == {
+        v,
+    }, "unlink() broke 22.6/s!"
+    assert set(helpers.neighbors(t)) == {x, y}, "unlink() broke 22.6/t!"
+    assert set(helpers.neighbors(u)) == {
+        y,
+    }, "unlink() broke 22.6/u!"
+    assert set(helpers.neighbors(v)) == {
+        w,
+    }, "unlink() broke 22.6/v!"
+    assert set(helpers.neighbors(w)) == {
+        s,
+    }, "unlink() broke 22.6/w!"
+    assert set(helpers.neighbors(x)) == set(), "unlink() broke 22.6/x!"
+    assert set(helpers.neighbors(y)) == {
+        q,
+    }, "unlink() broke 22.6/y!"
+    assert set(helpers.neighbors(z)) == set(), "unlink() broke 22.6/z!"
+
 
 def test_unlink_returns_links(graph_clrs09_22_6):
+    """
+    Ensure the unlink() function returns link objects when requested.
+    """
     _, verts = graph_clrs09_22_6
-    q, r, s, t, u, v, w, x, y, z = verts
+    x, z = verts[-3], verts[-1]
     links = helpers.find_links(x, z, direction_sensitive=False)
 
     undone = explicit.unlink(x, z, destroy=False)

--- a/tests/structure/test_universe.py
+++ b/tests/structure/test_universe.py
@@ -66,8 +66,8 @@ def test_universe_vertex_remove():
         vs.append(vertex.Vertex())
         u.add_vertex(vs[-1])
 
-    remove = vs[0:len(vs):2]
-    stay = vs[1:len(vs):2]
+    remove = vs[0 : len(vs) : 2]
+    stay = vs[1 : len(vs) : 2]
 
     for v in remove:
         u.remove_vertex(v)

--- a/tests/structure/test_universe.py
+++ b/tests/structure/test_universe.py
@@ -56,6 +56,30 @@ def test_universe_vertex_add():
     ), "universes.add_vertex did not set u in vertex.universes"
 
 
+def test_universe_vertex_remove():
+    """
+    Ensure we can remove a vertex from a universe.
+    """
+    u = universe.Universe()
+    vs = []
+    for i in range(20):
+        vs.append(vertex.Vertex())
+        u.add_vertex(vs[-1])
+
+    remove = vs[0:len(vs):2]
+    stay = vs[1:len(vs):2]
+
+    for v in remove:
+        u.remove_vertex(v)
+
+        assert v not in u.vertices, "remove_vertex did not (uni-side)!"
+        assert u not in v.universes, "remove_vertex did not (vert-side)!"
+
+    for v in stay:
+        assert v in u.vertices, "remove_vertex altered unreq vert (uni-side)!"
+        assert u in v.universes, "remove_vertex altered unreq vert (vert-siee)!"
+
+
 def test_universe_vertex_init():
     """
     Ensure we can pass vertices into a Universe instantiation.

--- a/tests/structure/test_vertex.py
+++ b/tests/structure/test_vertex.py
@@ -118,6 +118,7 @@ def test_vert_add_to_uni():
     for uni in unis:
         assert v in uni.vertices, "vertex add_to_universe did not back-ref!"
 
+
 def test_vert_rem_from_uni():
     """
     Ensure we can remove a Vertex from universes.
@@ -129,18 +130,27 @@ def test_vert_rem_from_uni():
         unis.append(universe.Universe())
         v.add_to_universe(unis[-1])
 
-    remove = unis[0:len(unis):2]
-    stay = unis[1:len(unis):2]
+    remove = unis[0 : len(unis) : 2]
+    stay = unis[1 : len(unis) : 2]
 
     for uni in remove:
         v.remove_from_universe(uni)
 
-        assert uni not in v.universes, "remove_from_universe did not remove vert-side!"
-        assert v not in uni.vertices, "remove_from_universes did not remove uni-side!"
+        assert (
+            uni not in v.universes
+        ), "remove_from_universe did not remove vert-side!"
+        assert (
+            v not in uni.vertices
+        ), "remove_from_universes did not remove uni-side!"
 
     for uni in stay:
-        assert uni in v.universes, "remove_from_universe altered unrequested uni, vert-side!"
-        assert v in uni.vertices, "remove_from_universe altered unrequested uni, uni-side!"
+        assert (
+            uni in v.universes
+        ), "remove_from_universe altered unrequested uni, vert-side!"
+        assert (
+            v in uni.vertices
+        ), "remove_from_universe altered unrequested uni, uni-side!"
+
 
 def test_vert_init_with_uni():
     """

--- a/tests/structure/test_vertex.py
+++ b/tests/structure/test_vertex.py
@@ -118,6 +118,29 @@ def test_vert_add_to_uni():
     for uni in unis:
         assert v in uni.vertices, "vertex add_to_universe did not back-ref!"
 
+def test_vert_rem_from_uni():
+    """
+    Ensure we can remove a Vertex from universes.
+    """
+    v = vertex.Vertex()
+
+    unis = []
+    for _ in range(50):
+        unis.append(universe.Universe())
+        v.add_to_universe(unis[-1])
+
+    remove = unis[0:len(unis):2]
+    stay = unis[1:len(unis):2]
+
+    for uni in remove:
+        v.remove_from_universe(uni)
+
+        assert uni not in v.universes, "remove_from_universe did not remove vert-side!"
+        assert v not in uni.vertices, "remove_from_universes did not remove uni-side!"
+
+    for uni in stay:
+        assert uni in v.universes, "remove_from_universe altered unrequested uni, vert-side!"
+        assert v in uni.vertices, "remove_from_universe altered unrequested uni, uni-side!"
 
 def test_vert_init_with_uni():
     """


### PR DESCRIPTION
Adds the following:

* `edgegraph.traversal.helpers.unlink()` to scrap all existing links between two vertices, maintaining overall graph integrity
* `edgegraph.structure.universe.remove_vertex()` to remove a vertex from a graph
* `edgegraph.structure.vertex.remove_from_universe()` to remove a vertex from a graph
* Unit tests & docstrings for all new items.

Closing this PR resolves #29 and #41 .