### PR TITLE
Add backwards-traversal options for traversals

### DIFF
--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -205,6 +205,6 @@ def bft(
                 queue.append(v)
 
     if ff_result:
-        return filter(ff_result, visited)
+        return list(filter(ff_result, visited))
     else:
         return visited

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -107,7 +107,14 @@ def bfs(uni: Universe, start: Vertex, attrib: str, val: object) -> Vertex:
     return None
 
 
-def bft(uni: Universe, start: Vertex) -> list[Vertex]:
+def bft(
+    uni: Universe,
+    start: Vertex,
+    direction_sensitive: int = helpers.DIR_SENS_FORWARD,
+    unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
+    ff_via: Callable = None,
+    ff_result: Callable = None,
+) -> list[Vertex]:
     """
     Perform a breadth-first traversal.
 
@@ -119,6 +126,55 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
 
     :param uni: The universe to search in.
     :param start: The vertex to start searching at.
+    :param direction_sensitive: Directly passed through to
+       :py:func:`~edgegraph.traversal.helpers.neighbors`.  This may be one of:
+
+       * :py:const:`~edgegraph.traversal.helpers.DIR_SENS_FORWARD` (default),
+         to follow edges only forward (when directed),
+       * :py:const:`~edgegraph.traversal.helpers.DIR_SENS_ANY`, to follow edges
+         regardless of their direction,
+       * :py:const:`~edgegraph.traversal.helpers.DIR_SENS_BACKWARD`, to only
+         follow edges backwards (when directed).
+
+    :param unknown_handling: Directly passed through to
+       :py:func:`~edgegraph.traversal.helpers.neighbors`.  This may be one of:
+
+       * :py:const:`~edgegraph.traversal.helpers.LNK_UNKNOWN_ERROR` (default),
+         to throw an exception,
+       * :py:const:`~edgegraph.traversal.helpers.LNK_UNKNOWN_NEIGHBOR`, to
+         treat such edges as neighbors (and take the edge),
+       * :py:const:`~edgegraph.traversal.helpers.LNK_UNKNOWN_NONNEIGHBOR`, to
+         treat such edges as non-neighbors (do not take the edge).
+
+    :param ff_via: Directly passed through to
+       :py:func:`~edgegraph.traversal.helpers.neighbors` function's
+       ``filterfunc`` argument.
+
+       .. py:function:: ff_via(e, v2)
+          :noindex:
+
+          Determines if an edge (``e``) from a given vertex to another (``v2``)
+          should be followed.  If not, that entire section of the graph will
+          not be traversed (assuming no other entries to that area).
+
+          :param e: The edge connecting ``v1`` to ``v2``.
+          :param v2: The vertex under consideration.
+          :return: Whether or not ``v2`` should be considered a neighbor of
+             ``v``, when reached via ``e``.
+
+    :param ff_result: Callable used to filter the final output, after traversal
+       has been completed.
+
+       .. py:function:: ff_result(v)
+          :noindex:
+
+          Determines if a vertex should be returned during the final output.
+          This can be useful if you want to mask certain vertices in the
+          result, but still traverse across them.
+
+          :param v: Vertex to be considered
+          :return: Whether or not ``v`` should be part of the output.
+
     :return: The vertices visited during traversal.
     """
     if (uni is not None) and (len(uni.vertices) == 0):
@@ -133,7 +189,12 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
 
     while queue:
         u = queue.popleft()
-        for v in helpers.neighbors(u):
+        for v in helpers.neighbors(
+            u,
+            direction_sensitive=direction_sensitive,
+            unknown_handling=unknown_handling,
+            filterfunc=ff_via,
+        ):
 
             if (uni is not None) and (v not in uni.vertices):
                 continue
@@ -143,4 +204,7 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
                 visited.append(v)
                 queue.append(v)
 
-    return visited
+    if ff_result:
+        return filter(ff_result, visited)
+    else:
+        return visited

--- a/edgegraph/traversal/depthfirst.py
+++ b/edgegraph/traversal/depthfirst.py
@@ -116,7 +116,7 @@ def _dft_recur(
             )
 
     if ff_result:
-        return filter(ff_result, out)
+        return list(filter(ff_result, out))
     return out
 
 
@@ -274,7 +274,7 @@ def dft_iterative(
             ):
                 stack.append(w)
     if ff_result:
-        return filter(ff_result, discovered)
+        return list(filter(ff_result, discovered))
     return discovered
 
 

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -257,7 +257,6 @@ def neighbors(
                     raise NotImplementedError(
                         f"Unknown link class {type(link)}"
                     )
-            
 
         elif direction_sensitive == DIR_SENS_ANY:
             # see above notes on short-circuiting filterfunc() if it's not

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -30,10 +30,40 @@ LNK_UNKNOWN_NEIGHBOR = 1
 #:    :py:func:`neighbors`
 LNK_UNKNOWN_ERROR = 2
 
+#: Follow links forward
+#:
+#: This option specifies that links between vertices should be followed in
+#: their direction (that is, normally).
+#:
+#: .. seealso::
+#:
+#:    :py:func:`neighbors`
+DIR_SENS_FORWARD = 0
+
+#: Follow links regardless of directionality
+#:
+#: This option specifies that links between vertices should be followed no
+#: matter what direction they point in (i.e., forwards or backwards).
+#:
+#: .. seealso::
+#:
+#:    :py:func:`neighbors`
+DIR_SENS_ANY = 1
+
+#: Follow links backwards
+#:
+#: This option specifies that links between vertices should be followed only
+#: against their directionality (backwards).
+#:
+#: .. seealso::
+#:
+#:    :py:func:`neighbors`
+DIR_SENS_BACKWARD = 2
+
 
 def neighbors(
     vert: Vertex,
-    direction_sensitive: bool = True,
+    direction_sensitive: int = DIR_SENS_FORWARD,
     unknown_handling: int = LNK_UNKNOWN_ERROR,
     filterfunc: Callable = None,
 ) -> list[Vertex]:
@@ -66,11 +96,11 @@ def neighbors(
 
     >>> neighbors(v1)
     [v2, v3]
-    >>> neighbors(v1, direction_sensitive=False)
+    >>> neighbors(v1, direction_sensitive=DIR_SENS_FORWARD)
     [v2, v3, v4]
     >>> neighbors(v4)
     [v1]
-    >>> neighbors(v4, direction_sensitive=False)
+    >>> neighbors(v4, direction_sensitive=DIR_SENS_ANY)
     [v1, v3]
 
     If supplied, the ``filterfunc`` argument should be to a callable object
@@ -105,11 +135,12 @@ def neighbors(
        ``direction_sensitive`` parameter!
 
     :param vert: The vertex to identify neighbors of.
-    :param direction_sensitive: Enables handling of directional links.  If set
-       to ``False``, any subclasses / instances of
-       :py:class:`~edgegraph.structure.directededge.DirectedEdge` are treated
-       as if they were instead subclasses / instances of
-       :py:class:`~edgegraph.structure.undirectededge.UnDirectedEdge`.
+    :param direction_sensitive: How to handle directional edges as they are
+       encountered.  :py:const:`DIR_SENS_FORWARD` will indicates "normal"
+       usages, where edges will only be followed outwards from the given
+       vertex.  :py:const:`DIR_SENS_ANY` will follow *any* edge, regardless of
+       whether it points to or from this vertex.  :py:const:`DIR_SENS_BACKWARD`
+       will follow only edges inbound to this vertex.
     :param unknown_handling: What to do with edges whose class is not
        recognized (not a subclass / instance of either
        :py:class:`~edgegraph.structure.directededge.DirectedEdge` or
@@ -131,7 +162,7 @@ def neighbors(
 
         v2 = link.other(vert)
 
-        if direction_sensitive:
+        if direction_sensitive == DIR_SENS_FORWARD:
             # undirected edges don't matter
             if issubclass(type(link), UnDirectedEdge):
 
@@ -187,11 +218,16 @@ def neighbors(
                         f"Unknown link class {type(link)}"
                     )
 
-        else:
+        elif direction_sensitive == DIR_SENS_ANY:
             # see above notes on short-circuiting filterfunc() if it's not
             # provided
             if filterfunc is None or filterfunc(link, v2):
                 nbs.append(v2)
+
+        else:
+            raise ValueError(
+                f"Unknown option for direction_sensitive = {direction_sensitive}"
+            )
 
     return nbs
 

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -218,6 +218,47 @@ def neighbors(
                         f"Unknown link class {type(link)}"
                     )
 
+        elif direction_sensitive == DIR_SENS_BACKWARD:
+
+            if issubclass(type(link), UnDirectedEdge):
+
+                if filterfunc is None or filterfunc(link, v2):
+                    nbs.append(v2)
+                else:
+                    # see comment on the above else: continue block for
+                    # explanation of this no-cover statement.
+                    continue  # pragma: no cover
+
+            # for directed edges, only add the neighbor if vert is the origin
+            elif issubclass(type(link), DirectedEdge) and (link.v2 is vert):
+
+                # see above notes on short-circuiting filterfunc() if it's not
+                # provided
+                if filterfunc is None or filterfunc(link, v2):
+                    nbs.append(v2)
+                else:
+                    # see comment on the above else: continue block for
+                    # explanation of this no-cover statement.
+                    continue  # pragma: no cover
+
+            # we're looking at v2 -- the destination
+            # TODO: is it more time efficient to move the v1/v2 comparison into
+            # an if nested under the directededge check?
+            elif issubclass(type(link), DirectedEdge) and (link.v1 is vert):
+                pass
+
+            else:
+                if unknown_handling == LNK_UNKNOWN_NONNEIGHBOR:
+                    continue
+
+                if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
+                    nbs.append(link.other(vert))
+                else:
+                    raise NotImplementedError(
+                        f"Unknown link class {type(link)}"
+                    )
+            
+
         elif direction_sensitive == DIR_SENS_ANY:
             # see above notes on short-circuiting filterfunc() if it's not
             # provided

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
+[tool.coverage.run]
+dynamic_context = "test_function"
+
+[tool.coverage.html]
+show_contexts = true
+
 [tool.black]
 line-length = 80
 

--- a/tests/traversal/test_breadthfirst.py
+++ b/tests/traversal/test_breadthfirst.py
@@ -189,6 +189,41 @@ def test_bft_none_universe(graph_clrs09_22_6):
     ], "BFT did not traverse when uni = None!"
 
 
+def test_bft_ff_result(graph_clrs09_22_6):
+    """
+    Ensure the ff_result parameter works on bft().
+    """
+    _, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(None, verts[1], ff_result=lambda v2: v2.i > 5)
+    trav = set(v.i for v in trav)
+    assert trav == {6, 7, 8, 9}
+
+
+def test_bft_ff_via(graph_clrs09_22_6):
+    """
+    Ensure the ff_via parameter works on bft().
+    """
+    _, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(None, verts[1], ff_via=lambda e, v2: v2.i % 2 == 0)
+    trav = set(v.i for v in trav)
+    assert trav == {0, 1, 2, 4, 6, 8}
+
+
+def test_bft_ff_via_and_result(graph_clrs09_22_6):
+    """
+    Ensure the ff_result *and* ff_via parameter work together on bft().
+    """
+    _, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(
+        None,
+        verts[1],
+        ff_via=lambda e, v2: v2.i % 2 == 0,
+        ff_result=lambda v2: v2.i > 5,
+    )
+    trav = set(v.i for v in trav)
+    assert trav == {6, 8}
+
+
 ###############################################################################
 # stress testing
 

--- a/tests/traversal/test_depthfirst.py
+++ b/tests/traversal/test_depthfirst.py
@@ -150,6 +150,29 @@ def test_dftr_none_universe(graph_clrs09_22_6):
     trav = [v.i for v in trav]
     assert trav == dftr_data[0][1], "DFTR did not traverse with uni = None"
 
+@pytest.mark.parametrize("func", travs)
+def test_dft_ff_result(graph_clrs09_22_6, func):
+    _, verts = graph_clrs09_22_6
+    trav = func(None, verts[1], ff_result=lambda v: v.i > 5)
+    trav = set(v.i for v in trav)
+    assert trav == {6, 7, 8, 9}
+
+@pytest.mark.parametrize("func", travs)
+def test_dft_ff_via(graph_clrs09_22_6, func):
+    _, verts = graph_clrs09_22_6
+    trav = func(None, verts[1], ff_via=lambda e, v2: v2.i % 2 == 0)
+    trav = set(v.i for v in trav)
+    assert trav == {0, 1, 2, 4, 6, 8}
+
+@pytest.mark.parametrize("func", travs)
+def test_dft_ff_via_and_result(graph_clrs09_22_6, func):
+    _, verts = graph_clrs09_22_6
+    trav = func(None, verts[1],
+            ff_via=lambda e, v2: v2.i % 2 == 0,
+            ff_result=lambda v: v.i > 5)
+    trav = set(v.i for v in trav)
+    assert trav == {6, 8}
+
 
 ###############################################################################
 # searches!

--- a/tests/traversal/test_depthfirst.py
+++ b/tests/traversal/test_depthfirst.py
@@ -150,26 +150,42 @@ def test_dftr_none_universe(graph_clrs09_22_6):
     trav = [v.i for v in trav]
     assert trav == dftr_data[0][1], "DFTR did not traverse with uni = None"
 
+
 @pytest.mark.parametrize("func", travs)
 def test_dft_ff_result(graph_clrs09_22_6, func):
+    """
+    Ensure the ff_result parameter works on depth-first traversals.
+    """
     _, verts = graph_clrs09_22_6
     trav = func(None, verts[1], ff_result=lambda v: v.i > 5)
     trav = set(v.i for v in trav)
     assert trav == {6, 7, 8, 9}
 
+
 @pytest.mark.parametrize("func", travs)
 def test_dft_ff_via(graph_clrs09_22_6, func):
+    """
+    Ensure the ff_via parameter works on depth-first traversals.
+    """
     _, verts = graph_clrs09_22_6
     trav = func(None, verts[1], ff_via=lambda e, v2: v2.i % 2 == 0)
     trav = set(v.i for v in trav)
     assert trav == {0, 1, 2, 4, 6, 8}
 
+
 @pytest.mark.parametrize("func", travs)
 def test_dft_ff_via_and_result(graph_clrs09_22_6, func):
+    """
+    Ensure the ff_result *and* ff_via parameter work together on depth-first
+    traversals.
+    """
     _, verts = graph_clrs09_22_6
-    trav = func(None, verts[1],
-            ff_via=lambda e, v2: v2.i % 2 == 0,
-            ff_result=lambda v: v.i > 5)
+    trav = func(
+        None,
+        verts[1],
+        ff_via=lambda e, v2: v2.i % 2 == 0,
+        ff_result=lambda v: v.i > 5,
+    )
     trav = set(v.i for v in trav)
     assert trav == {6, 8}
 

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -60,8 +60,9 @@ def test_neighbors_directed():
     }
     adjlist.load_adj_dict(adj, DirectedEdge)
 
-    v0nb = helpers.neighbors(v[0], direction_sensitive=True)
-    v1nb = helpers.neighbors(v[1], direction_sensitive=True)
+    v0nb = helpers.neighbors(v[0], direction_sensitive=helpers.DIR_SENS_FORWARD
+            )
+    v1nb = helpers.neighbors(v[1], direction_sensitive=helpers.DIR_SENS_FORWARD)
 
     assert v0nb == [v[1]], "v0 neighbors incorrect!"
     assert v1nb == [v[2]], "v1 neighbors incorrect!"
@@ -78,8 +79,8 @@ def test_neighbors_directed_nonsensitive():
     }
     adjlist.load_adj_dict(adj, DirectedEdge)
 
-    v0nb = helpers.neighbors(v[0], direction_sensitive=False)
-    v1nb = helpers.neighbors(v[1], direction_sensitive=False)
+    v0nb = helpers.neighbors(v[0], direction_sensitive=helpers.DIR_SENS_ANY)
+    v1nb = helpers.neighbors(v[1], direction_sensitive=helpers.DIR_SENS_ANY)
 
     assert v0nb == [v[1]], "v0 neighbors incorrect!"
     assert v1nb == [v[0], v[2]], "v1 neighbors incorrect!"
@@ -99,18 +100,18 @@ def test_neighbors_unknown_link_type():
     with pytest.raises(NotImplementedError):
         helpers.neighbors(
             v[0],
-            direction_sensitive=True,
+            direction_sensitive=helpers.DIR_SENS_FORWARD,
             unknown_handling=helpers.LNK_UNKNOWN_ERROR,
         )
 
     v0nb1 = helpers.neighbors(
         v[0],
-        direction_sensitive=True,
+        direction_sensitive=helpers.DIR_SENS_FORWARD,
         unknown_handling=helpers.LNK_UNKNOWN_NEIGHBOR,
     )
     v0nb2 = helpers.neighbors(
         v[0],
-        direction_sensitive=True,
+        direction_sensitive=helpers.DIR_SENS_FORWARD,
         unknown_handling=helpers.LNK_UNKNOWN_NONNEIGHBOR,
     )
 
@@ -180,7 +181,7 @@ def test_neighbors_filter_func_subclass_nondirected():
 
     nb1 = set(
         helpers.neighbors(
-            v[0], direction_sensitive=False, filterfunc=filterfunc
+            v[0], direction_sensitive=helpers.DIR_SENS_ANY, filterfunc=filterfunc
         )
     )
     assert nb1 == {
@@ -192,14 +193,14 @@ def test_neighbors_filter_func_subclass_nondirected():
 
     nb2 = set(
         helpers.neighbors(
-            v[2], direction_sensitive=False, filterfunc=filterfunc
+            v[2], direction_sensitive=helpers.DIR_SENS_ANY, filterfunc=filterfunc
         )
     )
     assert nb2 == {v[3], v[4], v[5]}, "Neighbors filterfunc gave wrong answer"
 
     nb3 = set(
         helpers.neighbors(
-            v[4], direction_sensitive=False, filterfunc=filterfunc
+            v[4], direction_sensitive=helpers.DIR_SENS_ANY, filterfunc=filterfunc
         )
     )
     assert nb3 == {v[2], v[3], v[5]}, "Neighbors filterfunc gave wrong answer"

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -177,6 +177,7 @@ def test_neighbors_unknown_link_type_backwards():
     assert v0nb1 == [v[1]], "LNK_UNKNOWN_NEIGHBOR behavior wrong!"
     assert v0nb2 == [], "LNK_UNKNOWN_NONNEIGHBOR behavior wrong!"
 
+
 def test_neighbors_filter_func_subclass_directededge():
     """
     Ensure the neighbors function filterfunc works in a vertex application.
@@ -317,11 +318,14 @@ def test_neighbors_filter_func_subclass_undirected():
     )
     assert nb3 == {v[2], v[3], v[5]}, "Neighbors filterfunc gave wrong answer"
 
+
 def test_neighbors_filter_func_subclass_directed_backwards():
     class VT1(Vertex):
         pass
+
     class VT2(VT1):
         pass
+
     #       0         1        2      3      4     5
     v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
     adj = {
@@ -333,25 +337,44 @@ def test_neighbors_filter_func_subclass_directed_backwards():
         v[5]: [v[0], v[2], v[4]],
     }
     adjlist.load_adj_dict(adj, DirectedEdge)
+
     def filterfunc(e, v2):
         return isinstance(v2, VT1)
 
-    nb1 = set(helpers.neighbors(v[0], direction_sensitive=helpers.DIR_SENS_BACKWARD, filterfunc=filterfunc))
+    nb1 = set(
+        helpers.neighbors(
+            v[0],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
     nb2 = set(
-        helpers.neighbors(v[2], direction_sensitive=helpers.DIR_SENS_BACKWARD, filterfunc=filterfunc))
+        helpers.neighbors(
+            v[2],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
     nb3 = set(
-        helpers.neighbors(v[4], direction_sensitive=helpers.DIR_SENS_BACKWARD, filterfunc=filterfunc)
+        helpers.neighbors(
+            v[4],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
     )
 
     assert nb1 == {v[2], v[3], v[4], v[5]}
     assert nb2 == {v[3], v[4], v[5]}
     assert nb3 == {v[2], v[3], v[5]}
 
+
 def test_neighbors_filter_func_subclass_undirected_backwards():
     class VT1(Vertex):
         pass
+
     class VT2(VT1):
         pass
+
     #       0         1        2      3      4     5
     v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
     adj = {
@@ -363,14 +386,30 @@ def test_neighbors_filter_func_subclass_undirected_backwards():
         v[5]: [v[0], v[2], v[4]],
     }
     adjlist.load_adj_dict(adj, UnDirectedEdge)
+
     def filterfunc(e, v2):
         return isinstance(v2, VT1)
 
-    nb1 = set(helpers.neighbors(v[0], direction_sensitive=helpers.DIR_SENS_BACKWARD, filterfunc=filterfunc))
+    nb1 = set(
+        helpers.neighbors(
+            v[0],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
     nb2 = set(
-        helpers.neighbors(v[2], direction_sensitive=helpers.DIR_SENS_BACKWARD, filterfunc=filterfunc))
+        helpers.neighbors(
+            v[2],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
     nb3 = set(
-        helpers.neighbors(v[4], direction_sensitive=helpers.DIR_SENS_BACKWARD, filterfunc=filterfunc)
+        helpers.neighbors(
+            v[4],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
     )
 
     assert nb1 == {v[2], v[3], v[4], v[5]}


### PR DESCRIPTION
Adds reverse traversal options and improves in-line filtering for depth- and breadth-first traversal functions.

When closed, resolves #30 and #31.