### PR TITLE
Pyvis local CDN resources by default

### DIFF
--- a/edgegraph/output/pyvis.py
+++ b/edgegraph/output/pyvis.py
@@ -58,7 +58,9 @@ from edgegraph.structure import Universe, DirectedEdge
 
 
 def make_pyvis_net(
-    uni: Universe, rvfunc: Callable = None, refunc: Callable = None,
+    uni: Universe,
+    rvfunc: Callable = None,
+    refunc: Callable = None,
     network_kwargs: dict = None,
 ) -> pyvis.network.Network:
     """
@@ -98,7 +100,7 @@ def make_pyvis_net(
     """
 
     if network_kwargs is None:
-        network_kwargs = {'cdn_resources': 'local'}
+        network_kwargs = {"cdn_resources": "local"}
     net = network.Network(**network_kwargs)
     verts = list(uni.vertices)
     for i, vert in enumerate(verts):

--- a/edgegraph/output/pyvis.py
+++ b/edgegraph/output/pyvis.py
@@ -58,7 +58,8 @@ from edgegraph.structure import Universe, DirectedEdge
 
 
 def make_pyvis_net(
-    uni: Universe, rvfunc: Callable = None, refunc: Callable = None
+    uni: Universe, rvfunc: Callable = None, refunc: Callable = None,
+    network_kwargs: dict = None,
 ) -> pyvis.network.Network:
     """
     Convert a given Universe to a PyVis network, suitable for further use
@@ -89,11 +90,16 @@ def make_pyvis_net(
        :py:class:`~edgegraph.structure.twoendedlink.TwoEndedLink`, or subclass
        thereof), and must return a :py:class:`str`.  If not provided, edges
        will not be labelled.
+    :param network_kwargs: An optional dictionary of keyword arguments to pass
+      to :py:class:`network.Network`.  If not supplied, the default will select
+      ``"cdn_resources": "local"`` and nothing else.
     :return: A :py:class:`pyvis.network.Network` instance containing the data
        found in the given universe.
     """
 
-    net = network.Network()
+    if network_kwargs is None:
+        network_kwargs = {'cdn_resources': 'local'}
+    net = network.Network(**network_kwargs)
     verts = list(uni.vertices)
     for i, vert in enumerate(verts):
         if rvfunc:

--- a/tests/output/test_pyvis.py
+++ b/tests/output/test_pyvis.py
@@ -121,3 +121,15 @@ def test_pyvis_vert_outside_uni_hard(graph_clrs09_22_6):
     assert len(nodes_present) == len(
         verts
     ), "Extra vertex detected in PyVIS network"
+
+def test_pyvis_create_with_options(graph_clrs09_22_6):
+    """
+    Ensure Pyvis network kwargs passthru works.
+    """
+    uni, _ = graph_clrs09_22_6
+
+    default = pyvis.make_pyvis_net(uni)
+    assert default.cdn_resources == 'local', "Wrong default CDN resources!"
+
+    modded = pyvis.make_pyvis_net(uni, network_kwargs={'cdn_resources': 'remote'})
+    assert modded.cdn_resources == "remote", "Wrong modified CDN resources!"

--- a/tests/output/test_pyvis.py
+++ b/tests/output/test_pyvis.py
@@ -122,6 +122,7 @@ def test_pyvis_vert_outside_uni_hard(graph_clrs09_22_6):
         verts
     ), "Extra vertex detected in PyVIS network"
 
+
 def test_pyvis_create_with_options(graph_clrs09_22_6):
     """
     Ensure Pyvis network kwargs passthru works.
@@ -129,7 +130,9 @@ def test_pyvis_create_with_options(graph_clrs09_22_6):
     uni, _ = graph_clrs09_22_6
 
     default = pyvis.make_pyvis_net(uni)
-    assert default.cdn_resources == 'local', "Wrong default CDN resources!"
+    assert default.cdn_resources == "local", "Wrong default CDN resources!"
 
-    modded = pyvis.make_pyvis_net(uni, network_kwargs={'cdn_resources': 'remote'})
+    modded = pyvis.make_pyvis_net(
+        uni, network_kwargs={"cdn_resources": "remote"}
+    )
     assert modded.cdn_resources == "remote", "Wrong modified CDN resources!"


### PR DESCRIPTION
Sets default option for PyVis CDN resources to `local`.  Also allows arbitrary options to be passed to the network instantiation.

Fixes #33 .