### PR TITLE
Semi-singleton multiple hashes

### DIFF
--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -330,6 +330,7 @@ def semi_singleton_metaclass(hashfunc: Callable = None) -> type:
         """
 
         __semisingleton_instance_map = {}
+        __semisingleton_hashfunc = hashfunc
 
         def __call__(cls, *args, **kwargs):
             key = hashfunc(args, kwargs)
@@ -340,6 +341,13 @@ def semi_singleton_metaclass(hashfunc: Callable = None) -> type:
             return cls.__semisingleton_instance_map[key]
 
     return _SemiSingleton
+
+
+def add_mapping(identifier: Hashable, obj: object):
+    cls = type(type(obj))
+    hashfunc = cls._SemiSingleton__semisingleton_hashfunc
+    hashid = hashfunc(*identifier)
+    cls._SemiSingleton__semisingleton_instance_map[hashid] = obj
 
 
 def get_all_semi_singleton_instances(cls: type) -> Generator[object]:

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -344,9 +344,52 @@ def semi_singleton_metaclass(hashfunc: Callable = None) -> type:
 
 
 def add_mapping(identifier: Hashable, obj: object):
+    """
+    Adds another mapping to a semi-singleton instance.
+
+    This function can be used to add another mapping to an instance of a
+    semi-singleton object.  It can be useful for situations where the same
+    object can have multiple "names" (or, sets of arguments), but it is
+    inefficient to implement this in the metaclass hash function.  Using this
+    function instead allows a memory-time tradeoff, tipping the balance towards
+    more memory usage in favor of a faster hash function (and therefore, object
+    instantiation).
+
+    >>> from edgegraph.singleton import semi_singleton_metaclass, add_mapping
+    >>> class SemiSingleton(metaclass=semi_singleton_metaclass()):
+    ...     def __init__(self, foo, bar=False):
+    ...         self.foo = foo
+    ...         self.bar = bar
+    ...
+    >>> s3 = SemiSingleton(37, True)  # different arguments -- different object
+    >>> s3
+    <__main__.SemiSingleton object at 0x01234567>
+    >>> s2 is s3
+    False
+    >>> add_mapping(((39,), {'bar': True}), s3)
+    >>> s4 = SemiSingleton(39, True)  # we get s3 again, despite different args
+    >>> s4
+    <__main__.SemiSingleton object at 0x01234567>
+    >>> s3 is s4
+    True
+
+    :param identifier: Two-tuple of arguments and keyword arguments that will
+      be passed to the class's ``__init__`` method.  Typically, the first
+      element is another tuple representing positional arguments, and the
+      second elemtn is a dictionary representing keyword arguments.
+    :param obj: The object to map the extra identifier to.  Henceforth after
+      this function, this object will be reachable by the identifier given as
+      well as any others it may have already had.
+    """
+    # get the metaclass type
     cls = type(type(obj))
+
+    # use the metaclass's hash function to line up with existing / future
+    # mappings
     hashfunc = cls._SemiSingleton__semisingleton_hashfunc
     hashid = hashfunc(*identifier)
+
+    # store the hashed identifier in the metaclass map of hashes to instances
     cls._SemiSingleton__semisingleton_instance_map[hashid] = obj
 
 

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -457,3 +457,20 @@ def test_semi_singleton_get():
     assert set(insts) == set(
         check
     ), "Did not get expected semi-singleton insts!"
+
+
+def test_semi_singleton_multiname_smoketest():
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+
+    singleton.add_mapping(((3,), {}), a2)
+
+    a3 = A(3)
+
+    assert a3 is a2
+
+

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -474,3 +474,31 @@ def test_semi_singleton_multiname_smoketest():
     assert a3 is a2
 
 
+def test_semi_singleton_multiname_no_crosscontamination():
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+    class B(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+    b1 = B(1)
+    b2 = B(2)
+
+    assert a1 is not a2
+    assert a1 is not b1
+    assert b1 is not b2
+    assert a2 is not b2
+
+    singleton.add_mapping(((3,), {}), a2)
+
+    a3 = A(3)
+    b3 = B(3)
+
+    assert a3 is a2
+    assert b3 is not b2
+    assert b3 is not a3
+
+

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -463,6 +463,7 @@ def test_semi_singleton_multiname_smoketest():
     """
     Smoketest for semi-singleton add_mapping() function; ensures functionality.
     """
+
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -481,9 +482,11 @@ def test_semi_singleton_multiname_no_crosscontamination():
     """
     Ensure add_mapping() has no side effects on other classes.
     """
+
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
+
     class B(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -512,6 +515,7 @@ def test_semi_singleton_multiname_multiple():
     """
     Ensure many mappings can point to a single instance, not just two.
     """
+
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -525,5 +529,3 @@ def test_semi_singleton_multiname_multiple():
 
         assert ai is a2, f"add_mapping() failed mult-test at {i}!"
         assert ai is not a1, f"add_mapping() side effect at {i}!"
-
-

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -460,6 +460,9 @@ def test_semi_singleton_get():
 
 
 def test_semi_singleton_multiname_smoketest():
+    """
+    Smoketest for semi-singleton add_mapping() function; ensures functionality.
+    """
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -471,10 +474,13 @@ def test_semi_singleton_multiname_smoketest():
 
     a3 = A(3)
 
-    assert a3 is a2
+    assert a3 is a2, "add_mapping() did not double-point instance!"
 
 
 def test_semi_singleton_multiname_no_crosscontamination():
+    """
+    Ensure add_mapping() has no side effects on other classes.
+    """
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -487,18 +493,37 @@ def test_semi_singleton_multiname_no_crosscontamination():
     b1 = B(1)
     b2 = B(2)
 
-    assert a1 is not a2
-    assert a1 is not b1
-    assert b1 is not b2
-    assert a2 is not b2
+    assert a1 is not a2, "pre add_mapping() bad setup!"
+    assert a1 is not b1, "pre add_mapping() bad setup!"
+    assert b1 is not b2, "pre add_mapping() bad setup!"
+    assert a2 is not b2, "pre add_mapping() bad setup!"
 
     singleton.add_mapping(((3,), {}), a2)
 
     a3 = A(3)
     b3 = B(3)
 
-    assert a3 is a2
-    assert b3 is not b2
-    assert b3 is not a3
+    assert a3 is a2, "add_mapping() didn't double-point instance!"
+    assert b3 is not b2, "add_mapping() caused side effect!"
+    assert b3 is not a3, "add_mapping() caused side effect!"
+
+
+def test_semi_singleton_multiname_multiple():
+    """
+    Ensure many mappings can point to a single instance, not just two.
+    """
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+
+    for i in range(100):
+        singleton.add_mapping(((i,), {}), a2)
+        ai = A(i)
+
+        assert ai is a2, f"add_mapping() failed mult-test at {i}!"
+        assert ai is not a1, f"add_mapping() side effect at {i}!"
 
 


### PR DESCRIPTION
Adds support for multiple hashes to return the same instance in a semi-singleton setting.  This is useful for multiple "names", or IDs, or what-have-you that should all point to the same object.

Closes #28 .