### PR TITLE
0.6.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ prof
 
 # developer mental sanity tracker
 TODO.md
+.tmux-startup.sh
 
 # distributon files
 dist/

--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -17,6 +17,7 @@ functions will get the necessary updates to match, and the API stays unchanged.
 from __future__ import annotations
 
 from edgegraph.structure import Vertex, DirectedEdge, UnDirectedEdge
+from edgegraph.traversal import helpers
 
 
 def link_from_to(v1: Vertex, lnktype: type, v2: Vertex, dontdup: bool = False):
@@ -51,6 +52,40 @@ def link_from_to(v1: Vertex, lnktype: type, v2: Vertex, dontdup: bool = False):
                 return lnk
 
     return lnktype(v1, v2)
+
+
+def unlink(v1: Vertex, v2: Vertex, destroy=True) -> None:
+    """
+    Remive all links between ``v1`` and ``v2``.
+
+    This function identifies and removes all links that exist between given
+    vertices ``v1`` and ``v2``.  If the ``destroy`` parameter is set (default),
+    then the link objects are also deleted; if not, they are returned in a set.
+
+    :param v1: One vertex to unlink.
+    :param v2: Other vertex to unlink.
+    :param destroy: Whether to automatically delete the link objects.
+    :return: None if ``destroy`` is True, otherwise, a set of links that were
+       removed.
+    """
+    links = helpers.find_links(v1, v2, direction_sensitive=False)
+
+    if not destroy:
+        out = set()
+
+    for link in links:
+        link.unlink_from(v1)
+        link.unlink_from(v2)
+
+        if destroy:
+            del link
+        else:
+            out.add(link)
+
+    if not destroy:
+        return out
+    else:
+        return None
 
 
 def link_directed(

--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -83,12 +83,11 @@ def unlink(v1: Vertex, v2: Vertex, destroy=True) -> None:
             # pylint: disable-next=possibly-used-before-assignment
             out.add(link)
 
-
     if destroy:
         # TODO: is this actually useful?  need to investigate.  May not do
         # quite what it says on the tin.
         links = list(links)
-        for i in range(len(links)-1, -1, -1):
+        for i in range(len(links) - 1, -1, -1):
             del links[i]
 
     if not destroy:

--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -77,15 +77,23 @@ def unlink(v1: Vertex, v2: Vertex, destroy=True) -> None:
         link.unlink_from(v1)
         link.unlink_from(v2)
 
-        if destroy:
-            del link
-        else:
+        if not destroy:
+            # `out` is conditionally defined if destroy=False; we use it here
+            # under the same conditions, ergo, no issue.
+            # pylint: disable-next=possibly-used-before-assignment
             out.add(link)
+
+
+    if destroy:
+        # TODO: is this actually useful?  need to investigate.  May not do
+        # quite what it says on the tin.
+        links = list(links)
+        for i in range(len(links)-1, -1, -1):
+            del links[i]
 
     if not destroy:
         return out
-    else:
-        return None
+    return None
 
 
 def link_directed(

--- a/edgegraph/output/pyvis.py
+++ b/edgegraph/output/pyvis.py
@@ -58,7 +58,10 @@ from edgegraph.structure import Universe, DirectedEdge
 
 
 def make_pyvis_net(
-    uni: Universe, rvfunc: Callable = None, refunc: Callable = None
+    uni: Universe,
+    rvfunc: Callable = None,
+    refunc: Callable = None,
+    network_kwargs: dict = None,
 ) -> pyvis.network.Network:
     """
     Convert a given Universe to a PyVis network, suitable for further use
@@ -89,11 +92,16 @@ def make_pyvis_net(
        :py:class:`~edgegraph.structure.twoendedlink.TwoEndedLink`, or subclass
        thereof), and must return a :py:class:`str`.  If not provided, edges
        will not be labelled.
+    :param network_kwargs: An optional dictionary of keyword arguments to pass
+      to :py:class:`network.Network`.  If not supplied, the default will select
+      ``"cdn_resources": "local"`` and nothing else.
     :return: A :py:class:`pyvis.network.Network` instance containing the data
        found in the given universe.
     """
 
-    net = network.Network()
+    if network_kwargs is None:
+        network_kwargs = {"cdn_resources": "local"}
+    net = network.Network(**network_kwargs)
     verts = list(uni.vertices)
     for i, vert in enumerate(verts):
         if rvfunc:

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -236,6 +236,20 @@ class Universe(vertex.Vertex):
         if self not in vert.universes:
             vert.add_to_universe(self)
 
+    def remove_vertex(self, vert: vertex.Vertex):
+        """
+        Remove a vertex from this universe.
+
+        The vertex in question will be removed from this universe's record of
+        vertices.  If necessary. this universe will then be removed from the
+        vertices' record of universes as well.
+
+        :param vert: the vertex to be removed
+        """
+        self._vertices.remove(vert)
+        if self in vert.universes:
+            vert.remove_from_universe(self)
+
     @property
     def laws(self) -> UniverseLaws:
         """

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -116,3 +116,18 @@ class Vertex(base.BaseObject):
         if link in self._links:
             self._links.remove(link)
             link.unlink_from(self)
+
+    def remove_from_universe(self, universe: Universe) -> None:
+        """
+        Remove this vertex from the specified universe.
+
+        In addition to the superclass method, also removes the vertex from the
+        universe's record of vertices as well as simply removing the universe
+        from this vertices' record of universes if necessary.
+
+        :param universe: the universe that this vertex will be removed from
+        :raises KeyError: if this object is not present in the given universe
+        """
+        super().remove_from_universe(universe)
+        if self in universe.vertices:
+            universe.remove_vertex(self)

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -107,7 +107,14 @@ def bfs(uni: Universe, start: Vertex, attrib: str, val: object) -> Vertex:
     return None
 
 
-def bft(uni: Universe, start: Vertex) -> list[Vertex]:
+def bft(
+    uni: Universe,
+    start: Vertex,
+    direction_sensitive: int = helpers.DIR_SENS_FORWARD,
+    unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
+    ff_via: Callable = None,
+    ff_result: Callable = None,
+) -> list[Vertex]:
     """
     Perform a breadth-first traversal.
 
@@ -119,6 +126,55 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
 
     :param uni: The universe to search in.
     :param start: The vertex to start searching at.
+    :param direction_sensitive: Directly passed through to
+       :py:func:`~edgegraph.traversal.helpers.neighbors`.  This may be one of:
+
+       * :py:const:`~edgegraph.traversal.helpers.DIR_SENS_FORWARD` (default),
+         to follow edges only forward (when directed),
+       * :py:const:`~edgegraph.traversal.helpers.DIR_SENS_ANY`, to follow edges
+         regardless of their direction,
+       * :py:const:`~edgegraph.traversal.helpers.DIR_SENS_BACKWARD`, to only
+         follow edges backwards (when directed).
+
+    :param unknown_handling: Directly passed through to
+       :py:func:`~edgegraph.traversal.helpers.neighbors`.  This may be one of:
+
+       * :py:const:`~edgegraph.traversal.helpers.LNK_UNKNOWN_ERROR` (default),
+         to throw an exception,
+       * :py:const:`~edgegraph.traversal.helpers.LNK_UNKNOWN_NEIGHBOR`, to
+         treat such edges as neighbors (and take the edge),
+       * :py:const:`~edgegraph.traversal.helpers.LNK_UNKNOWN_NONNEIGHBOR`, to
+         treat such edges as non-neighbors (do not take the edge).
+
+    :param ff_via: Directly passed through to
+       :py:func:`~edgegraph.traversal.helpers.neighbors` function's
+       ``filterfunc`` argument.
+
+       .. py:function:: ff_via(e, v2)
+          :noindex:
+
+          Determines if an edge (``e``) from a given vertex to another (``v2``)
+          should be followed.  If not, that entire section of the graph will
+          not be traversed (assuming no other entries to that area).
+
+          :param e: The edge connecting ``v1`` to ``v2``.
+          :param v2: The vertex under consideration.
+          :return: Whether or not ``v2`` should be considered a neighbor of
+             ``v``, when reached via ``e``.
+
+    :param ff_result: Callable used to filter the final output, after traversal
+       has been completed.
+
+       .. py:function:: ff_result(v)
+          :noindex:
+
+          Determines if a vertex should be returned during the final output.
+          This can be useful if you want to mask certain vertices in the
+          result, but still traverse across them.
+
+          :param v: Vertex to be considered
+          :return: Whether or not ``v`` should be part of the output.
+
     :return: The vertices visited during traversal.
     """
     if (uni is not None) and (len(uni.vertices) == 0):
@@ -133,7 +189,12 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
 
     while queue:
         u = queue.popleft()
-        for v in helpers.neighbors(u):
+        for v in helpers.neighbors(
+            u,
+            direction_sensitive=direction_sensitive,
+            unknown_handling=unknown_handling,
+            filterfunc=ff_via,
+        ):
 
             if (uni is not None) and (v not in uni.vertices):
                 continue
@@ -143,4 +204,7 @@ def bft(uni: Universe, start: Vertex) -> list[Vertex]:
                 visited.append(v)
                 queue.append(v)
 
-    return visited
+    if ff_result:
+        return list(filter(ff_result, visited))
+    else:
+        return visited

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -53,7 +53,7 @@ import collections
 from edgegraph.structure import Universe, Vertex
 from edgegraph.traversal import helpers
 
-# TODO: add (to both these fn's) passthru kwargs to neighbors() options
+# TODO: add (search fn) passthru kwargs to neighbors() options
 
 
 def bfs(uni: Universe, start: Vertex, attrib: str, val: object) -> Vertex:
@@ -206,5 +206,4 @@ def bft(
 
     if ff_result:
         return list(filter(ff_result, visited))
-    else:
-        return visited
+    return visited

--- a/edgegraph/traversal/depthfirst.py
+++ b/edgegraph/traversal/depthfirst.py
@@ -73,7 +73,13 @@ def _df_preflight_checks(uni: Universe, start: Vertex):
 
 
 def _dft_recur(
-    uni: Universe, v: Vertex, visited: dict[Vertex, None]
+    uni: Universe,
+    v: Vertex,
+    visited: dict[Vertex, None],
+    direction_sensitive: int,
+    unknown_handling: int,
+    ff_via: Callable,
+    ff_result: Callable,
 ) -> list[Vertex]:
     """
     Recursion helper for :py:func:`dft_recursive`.  For internal use only!
@@ -88,15 +94,40 @@ def _dft_recur(
     """
     visited[v] = None
     out = [v]
-    for w in helpers.neighbors(v):
+    for w in helpers.neighbors(
+        v,
+        direction_sensitive=direction_sensitive,
+        unknown_handling=unknown_handling,
+        filterfunc=ff_via,
+    ):
         if (uni is not None) and (w not in uni.vertices):
             continue
         if w not in visited:
-            out.extend(_dft_recur(uni, w, visited))
+            out.extend(
+                _dft_recur(
+                    uni,
+                    w,
+                    visited,
+                    direction_sensitive,
+                    unknown_handling,
+                    ff_via,
+                    ff_result,
+                )
+            )
+
+    if ff_result:
+        return list(filter(ff_result, out))
     return out
 
 
-def dft_recursive(uni: Universe, start: Vertex) -> list[Vertex]:
+def dft_recursive(
+    uni: Universe,
+    start: Vertex,
+    direction_sensitive: int = helpers.DIR_SENS_FORWARD,
+    unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
+    ff_via: Callable = None,
+    ff_result: Callable = None,
+) -> list[Vertex]:
     """
     Perform a recursive depth-first traversal of the given universe, starting
     at the given vertex.
@@ -116,7 +147,15 @@ def dft_recursive(uni: Universe, start: Vertex) -> list[Vertex]:
     _df_preflight_checks(uni, start)
 
     visited = {}
-    return _dft_recur(uni, start, visited)
+    return _dft_recur(
+        uni,
+        start,
+        visited,
+        direction_sensitive,
+        unknown_handling,
+        ff_via,
+        ff_result,
+    )
 
 
 def _dfs_recur(
@@ -193,7 +232,14 @@ def dfs_recursive(
     return _dfs_recur(uni, start, visited, attrib, val)
 
 
-def dft_iterative(uni: Universe, start: Vertex) -> list[Vertex]:
+def dft_iterative(
+    uni: Universe,
+    start: Vertex,
+    direction_sensitive: int = helpers.DIR_SENS_FORWARD,
+    unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
+    ff_via: Callable = None,
+    ff_result: Callable = None,
+) -> list[Vertex]:
     """
     Perform an iterative depth-first traversal of the given universe, starting
     at the given vertex.
@@ -220,8 +266,15 @@ def dft_iterative(uni: Universe, start: Vertex) -> list[Vertex]:
             if (uni is not None) and (v not in uni.vertices):
                 continue
             discovered.append(v)
-            for w in helpers.neighbors(v):
+            for w in helpers.neighbors(
+                v,
+                direction_sensitive=direction_sensitive,
+                unknown_handling=unknown_handling,
+                filterfunc=ff_via,
+            ):
                 stack.append(w)
+    if ff_result:
+        return list(filter(ff_result, discovered))
     return discovered
 
 

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -30,10 +30,40 @@ LNK_UNKNOWN_NEIGHBOR = 1
 #:    :py:func:`neighbors`
 LNK_UNKNOWN_ERROR = 2
 
+#: Follow links forward
+#:
+#: This option specifies that links between vertices should be followed in
+#: their direction (that is, normally).
+#:
+#: .. seealso::
+#:
+#:    :py:func:`neighbors`
+DIR_SENS_FORWARD = 0
+
+#: Follow links regardless of directionality
+#:
+#: This option specifies that links between vertices should be followed no
+#: matter what direction they point in (i.e., forwards or backwards).
+#:
+#: .. seealso::
+#:
+#:    :py:func:`neighbors`
+DIR_SENS_ANY = 1
+
+#: Follow links backwards
+#:
+#: This option specifies that links between vertices should be followed only
+#: against their directionality (backwards).
+#:
+#: .. seealso::
+#:
+#:    :py:func:`neighbors`
+DIR_SENS_BACKWARD = 2
+
 
 def neighbors(
     vert: Vertex,
-    direction_sensitive: bool = True,
+    direction_sensitive: int = DIR_SENS_FORWARD,
     unknown_handling: int = LNK_UNKNOWN_ERROR,
     filterfunc: Callable = None,
 ) -> list[Vertex]:
@@ -66,11 +96,11 @@ def neighbors(
 
     >>> neighbors(v1)
     [v2, v3]
-    >>> neighbors(v1, direction_sensitive=False)
+    >>> neighbors(v1, direction_sensitive=DIR_SENS_FORWARD)
     [v2, v3, v4]
     >>> neighbors(v4)
     [v1]
-    >>> neighbors(v4, direction_sensitive=False)
+    >>> neighbors(v4, direction_sensitive=DIR_SENS_ANY)
     [v1, v3]
 
     If supplied, the ``filterfunc`` argument should be to a callable object
@@ -105,11 +135,12 @@ def neighbors(
        ``direction_sensitive`` parameter!
 
     :param vert: The vertex to identify neighbors of.
-    :param direction_sensitive: Enables handling of directional links.  If set
-       to ``False``, any subclasses / instances of
-       :py:class:`~edgegraph.structure.directededge.DirectedEdge` are treated
-       as if they were instead subclasses / instances of
-       :py:class:`~edgegraph.structure.undirectededge.UnDirectedEdge`.
+    :param direction_sensitive: How to handle directional edges as they are
+       encountered.  :py:const:`DIR_SENS_FORWARD` will indicates "normal"
+       usages, where edges will only be followed outwards from the given
+       vertex.  :py:const:`DIR_SENS_ANY` will follow *any* edge, regardless of
+       whether it points to or from this vertex.  :py:const:`DIR_SENS_BACKWARD`
+       will follow only edges inbound to this vertex.
     :param unknown_handling: What to do with edges whose class is not
        recognized (not a subclass / instance of either
        :py:class:`~edgegraph.structure.directededge.DirectedEdge` or
@@ -131,7 +162,7 @@ def neighbors(
 
         v2 = link.other(vert)
 
-        if direction_sensitive:
+        if direction_sensitive == DIR_SENS_FORWARD:
             # undirected edges don't matter
             if issubclass(type(link), UnDirectedEdge):
 
@@ -187,11 +218,56 @@ def neighbors(
                         f"Unknown link class {type(link)}"
                     )
 
-        else:
+        elif direction_sensitive == DIR_SENS_BACKWARD:
+
+            if issubclass(type(link), UnDirectedEdge):
+
+                if filterfunc is None or filterfunc(link, v2):
+                    nbs.append(v2)
+                else:
+                    # see comment on the above else: continue block for
+                    # explanation of this no-cover statement.
+                    continue  # pragma: no cover
+
+            # for directed edges, only add the neighbor if vert is the origin
+            elif issubclass(type(link), DirectedEdge) and (link.v2 is vert):
+
+                # see above notes on short-circuiting filterfunc() if it's not
+                # provided
+                if filterfunc is None or filterfunc(link, v2):
+                    nbs.append(v2)
+                else:
+                    # see comment on the above else: continue block for
+                    # explanation of this no-cover statement.
+                    continue  # pragma: no cover
+
+            # we're looking at v2 -- the destination
+            # TODO: is it more time efficient to move the v1/v2 comparison into
+            # an if nested under the directededge check?
+            elif issubclass(type(link), DirectedEdge) and (link.v1 is vert):
+                pass
+
+            else:
+                if unknown_handling == LNK_UNKNOWN_NONNEIGHBOR:
+                    continue
+
+                if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
+                    nbs.append(link.other(vert))
+                else:
+                    raise NotImplementedError(
+                        f"Unknown link class {type(link)}"
+                    )
+
+        elif direction_sensitive == DIR_SENS_ANY:
             # see above notes on short-circuiting filterfunc() if it's not
             # provided
             if filterfunc is None or filterfunc(link, v2):
                 nbs.append(v2)
+
+        else:
+            raise ValueError(
+                f"Unknown option for direction_sensitive = {direction_sensitive}"
+            )
 
     return nbs
 

--- a/edgegraph/version.py
+++ b/edgegraph/version.py
@@ -15,7 +15,7 @@ VERSION_MAJOR = 0
 #: minor version number (the Y in vX.Y.Z)
 #:
 #: :type: int
-VERSION_MINOR = 5
+VERSION_MINOR = 6
 
 #: patch version number (the Z in vX.Y.Z)
 #:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,12 @@ log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
+[tool.coverage.run]
+dynamic_context = "test_function"
+
+[tool.coverage.html]
+show_contexts = true
+
 [tool.black]
 line-length = 80
 

--- a/tests/builder/test_explicit.py
+++ b/tests/builder/test_explicit.py
@@ -98,11 +98,11 @@ def test_unlink_multiple():
     v1 = Vertex()
     v2 = Vertex()
     links = []
-    for i in range(30):
+    for _ in range(30):
         links.append(explicit.link_directed(v1, v2))
-    for i in range(30):
+    for _ in range(30):
         links.append(explicit.link_undirected(v1, v2))
-    for i in range(30):
+    for _ in range(30):
         links.append(explicit.link_from_to(v1, TwoEndedLink, v2))
 
     assert len(v1.links) == len(links), "wrong starting conditions!"

--- a/tests/builder/test_explicit.py
+++ b/tests/builder/test_explicit.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Unit tests for structure.twoendedlink.TwoEndedLink class.
+Unit tests for builder.explicit module.
 """
 
 from edgegraph.structure import (
@@ -12,6 +12,7 @@ from edgegraph.structure import (
     UnDirectedEdge,
 )
 from edgegraph.builder import explicit
+from edgegraph.traversal import helpers
 
 
 def test_link_basecls():
@@ -73,6 +74,111 @@ def test_link_undirected():
     lnk = explicit.link_undirected(v1, v2)
 
     assert isinstance(lnk, UnDirectedEdge)
+
+
+def test_unlink_basic():
+    """
+    Ensure the unlink() function works on single-linked cases.
+    """
+    v1 = Vertex()
+    v2 = Vertex()
+    lnk = explicit.link_undirected(v1, v2)
+
+    explicit.unlink(v1, v2)
+
+    assert len(lnk.vertices) == 0, "unlink did not clean link.vertices!"
+    assert len(v1.links) == 0, "unlink did not clean v1.links!"
+    assert len(v2.links) == 0, "unlink did not clean v2.links!"
+
+
+def test_unlink_multiple():
+    """
+    Ensure the unlink() function works on multiple-linked cases.
+    """
+    v1 = Vertex()
+    v2 = Vertex()
+    links = []
+    for i in range(30):
+        links.append(explicit.link_directed(v1, v2))
+    for i in range(30):
+        links.append(explicit.link_undirected(v1, v2))
+    for i in range(30):
+        links.append(explicit.link_from_to(v1, TwoEndedLink, v2))
+
+    assert len(v1.links) == len(links), "wrong starting conditions!"
+    assert len(v2.links) == len(links), "wrong starting conditions!"
+
+    explicit.unlink(v1, v2)
+
+    for link in links:
+        assert len(link.vertices) == 0, f"unlink did not clean {link}.vertices!"
+    assert len(v1.links) == 0, "unlink did not clean v1.links!"
+    assert len(v2.links) == 0, "unlink did not clean v2.links!"
+
+
+def test_unlink_in_situ(graph_clrs09_22_6):
+    """
+    Tests the unlinking logic in a real graph scenario.
+
+    This test ensure that unlinking two nodes in a graph doesn't alter any of
+    the other links around them.
+    """
+    _, verts = graph_clrs09_22_6
+    q, r, s, t, u, v, w, x, y, z = verts
+
+    # test scenario with only one link between objects
+    assert len(r.links) == 2, "wrong starting conditions!"
+    assert len(u.links) == 2, "wrong starting conditions!"
+
+    explicit.unlink(r, u)
+
+    assert len(r.links) == 1, "unlink() did not clean r.links!"
+    assert len(u.links) == 1, "unlink() did not clean u.links!"
+
+    # test scenario with multiple (two) links between objects
+    assert len(x.links) == 3, "wrong starting conditions!"
+    assert len(z.links) == 2, "wrong starting conditions!"
+
+    explicit.unlink(x, z)
+
+    assert len(x.links) == 1, "unlink() did not clean x.links()!"
+    assert len(z.links) == 0, "unlink() did not clean z.links()!"
+
+    assert set(helpers.neighbors(q)) == {s, t, w}, "unlink() broke 22.6/q!"
+    assert set(helpers.neighbors(r)) == {
+        y,
+    }, "unlink() broke 22.6/r!"
+    assert set(helpers.neighbors(s)) == {
+        v,
+    }, "unlink() broke 22.6/s!"
+    assert set(helpers.neighbors(t)) == {x, y}, "unlink() broke 22.6/t!"
+    assert set(helpers.neighbors(u)) == {
+        y,
+    }, "unlink() broke 22.6/u!"
+    assert set(helpers.neighbors(v)) == {
+        w,
+    }, "unlink() broke 22.6/v!"
+    assert set(helpers.neighbors(w)) == {
+        s,
+    }, "unlink() broke 22.6/w!"
+    assert set(helpers.neighbors(x)) == set(), "unlink() broke 22.6/x!"
+    assert set(helpers.neighbors(y)) == {
+        q,
+    }, "unlink() broke 22.6/y!"
+    assert set(helpers.neighbors(z)) == set(), "unlink() broke 22.6/z!"
+
+
+def test_unlink_returns_links(graph_clrs09_22_6):
+    """
+    Ensure the unlink() function returns link objects when requested.
+    """
+    _, verts = graph_clrs09_22_6
+    x, z = verts[-3], verts[-1]
+    links = helpers.find_links(x, z, direction_sensitive=False)
+
+    undone = explicit.unlink(x, z, destroy=False)
+
+    assert undone == links, "unlink() did not return expected links??"
 
 
 def test_link_basecls_chain():

--- a/tests/integration/test_performance.py
+++ b/tests/integration/test_performance.py
@@ -10,7 +10,7 @@ import logging
 import time
 import pytest
 from edgegraph.builder import randgraph
-from edgegraph.traversal import breadthfirst, depthfirst
+from edgegraph.traversal import breadthfirst
 
 pytestmark = pytest.mark.perf
 

--- a/tests/output/test_pyvis.py
+++ b/tests/output/test_pyvis.py
@@ -121,3 +121,18 @@ def test_pyvis_vert_outside_uni_hard(graph_clrs09_22_6):
     assert len(nodes_present) == len(
         verts
     ), "Extra vertex detected in PyVIS network"
+
+
+def test_pyvis_create_with_options(graph_clrs09_22_6):
+    """
+    Ensure Pyvis network kwargs passthru works.
+    """
+    uni, _ = graph_clrs09_22_6
+
+    default = pyvis.make_pyvis_net(uni)
+    assert default.cdn_resources == "local", "Wrong default CDN resources!"
+
+    modded = pyvis.make_pyvis_net(
+        uni, network_kwargs={"cdn_resources": "remote"}
+    )
+    assert modded.cdn_resources == "remote", "Wrong modified CDN resources!"

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -457,3 +457,75 @@ def test_semi_singleton_get():
     assert set(insts) == set(
         check
     ), "Did not get expected semi-singleton insts!"
+
+
+def test_semi_singleton_multiname_smoketest():
+    """
+    Smoketest for semi-singleton add_mapping() function; ensures functionality.
+    """
+
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+
+    singleton.add_mapping(((3,), {}), a2)
+
+    a3 = A(3)
+
+    assert a3 is a2, "add_mapping() did not double-point instance!"
+
+
+def test_semi_singleton_multiname_no_crosscontamination():
+    """
+    Ensure add_mapping() has no side effects on other classes.
+    """
+
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    class B(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+    b1 = B(1)
+    b2 = B(2)
+
+    assert a1 is not a2, "pre add_mapping() bad setup!"
+    assert a1 is not b1, "pre add_mapping() bad setup!"
+    assert b1 is not b2, "pre add_mapping() bad setup!"
+    assert a2 is not b2, "pre add_mapping() bad setup!"
+
+    singleton.add_mapping(((3,), {}), a2)
+
+    a3 = A(3)
+    b3 = B(3)
+
+    assert a3 is a2, "add_mapping() didn't double-point instance!"
+    assert b3 is not b2, "add_mapping() caused side effect!"
+    assert b3 is not a3, "add_mapping() caused side effect!"
+
+
+def test_semi_singleton_multiname_multiple():
+    """
+    Ensure many mappings can point to a single instance, not just two.
+    """
+
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+
+    for i in range(100):
+        singleton.add_mapping(((i,), {}), a2)
+        ai = A(i)
+
+        assert ai is a2, f"add_mapping() failed mult-test at {i}!"
+        assert ai is not a1, f"add_mapping() side effect at {i}!"

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -475,6 +475,7 @@ def test_semi_singleton_multiname_smoketest():
 
     a3 = A(3)
 
+    assert a1 is not a2, "add_mapping() added unwanted relationship!"
     assert a3 is a2, "add_mapping() did not double-point instance!"
 
 

--- a/tests/structure/test_universe.py
+++ b/tests/structure/test_universe.py
@@ -62,7 +62,7 @@ def test_universe_vertex_remove():
     """
     u = universe.Universe()
     vs = []
-    for i in range(20):
+    for _ in range(20):
         vs.append(vertex.Vertex())
         u.add_vertex(vs[-1])
 

--- a/tests/structure/test_universe.py
+++ b/tests/structure/test_universe.py
@@ -56,6 +56,30 @@ def test_universe_vertex_add():
     ), "universes.add_vertex did not set u in vertex.universes"
 
 
+def test_universe_vertex_remove():
+    """
+    Ensure we can remove a vertex from a universe.
+    """
+    u = universe.Universe()
+    vs = []
+    for i in range(20):
+        vs.append(vertex.Vertex())
+        u.add_vertex(vs[-1])
+
+    remove = vs[0 : len(vs) : 2]
+    stay = vs[1 : len(vs) : 2]
+
+    for v in remove:
+        u.remove_vertex(v)
+
+        assert v not in u.vertices, "remove_vertex did not (uni-side)!"
+        assert u not in v.universes, "remove_vertex did not (vert-side)!"
+
+    for v in stay:
+        assert v in u.vertices, "remove_vertex altered unreq vert (uni-side)!"
+        assert u in v.universes, "remove_vertex altered unreq vert (vert-siee)!"
+
+
 def test_universe_vertex_init():
     """
     Ensure we can pass vertices into a Universe instantiation.

--- a/tests/structure/test_vertex.py
+++ b/tests/structure/test_vertex.py
@@ -119,6 +119,39 @@ def test_vert_add_to_uni():
         assert v in uni.vertices, "vertex add_to_universe did not back-ref!"
 
 
+def test_vert_rem_from_uni():
+    """
+    Ensure we can remove a Vertex from universes.
+    """
+    v = vertex.Vertex()
+
+    unis = []
+    for _ in range(50):
+        unis.append(universe.Universe())
+        v.add_to_universe(unis[-1])
+
+    remove = unis[0 : len(unis) : 2]
+    stay = unis[1 : len(unis) : 2]
+
+    for uni in remove:
+        v.remove_from_universe(uni)
+
+        assert (
+            uni not in v.universes
+        ), "remove_from_universe did not remove vert-side!"
+        assert (
+            v not in uni.vertices
+        ), "remove_from_universes did not remove uni-side!"
+
+    for uni in stay:
+        assert (
+            uni in v.universes
+        ), "remove_from_universe altered unrequested uni, vert-side!"
+        assert (
+            v in uni.vertices
+        ), "remove_from_universe altered unrequested uni, uni-side!"
+
+
 def test_vert_init_with_uni():
     """
     Ensure vertices init'd with universes are members of them.

--- a/tests/traversal/test_breadthfirst.py
+++ b/tests/traversal/test_breadthfirst.py
@@ -189,6 +189,41 @@ def test_bft_none_universe(graph_clrs09_22_6):
     ], "BFT did not traverse when uni = None!"
 
 
+def test_bft_ff_result(graph_clrs09_22_6):
+    """
+    Ensure the ff_result parameter works on bft().
+    """
+    _, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(None, verts[1], ff_result=lambda v2: v2.i > 5)
+    trav = set(v.i for v in trav)
+    assert trav == {6, 7, 8, 9}
+
+
+def test_bft_ff_via(graph_clrs09_22_6):
+    """
+    Ensure the ff_via parameter works on bft().
+    """
+    _, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(None, verts[1], ff_via=lambda e, v2: v2.i % 2 == 0)
+    trav = set(v.i for v in trav)
+    assert trav == {0, 1, 2, 4, 6, 8}
+
+
+def test_bft_ff_via_and_result(graph_clrs09_22_6):
+    """
+    Ensure the ff_result *and* ff_via parameter work together on bft().
+    """
+    _, verts = graph_clrs09_22_6
+    trav = breadthfirst.bft(
+        None,
+        verts[1],
+        ff_via=lambda e, v2: v2.i % 2 == 0,
+        ff_result=lambda v2: v2.i > 5,
+    )
+    trav = set(v.i for v in trav)
+    assert trav == {6, 8}
+
+
 ###############################################################################
 # stress testing
 

--- a/tests/traversal/test_depthfirst.py
+++ b/tests/traversal/test_depthfirst.py
@@ -151,6 +151,45 @@ def test_dftr_none_universe(graph_clrs09_22_6):
     assert trav == dftr_data[0][1], "DFTR did not traverse with uni = None"
 
 
+@pytest.mark.parametrize("func", travs)
+def test_dft_ff_result(graph_clrs09_22_6, func):
+    """
+    Ensure the ff_result parameter works on depth-first traversals.
+    """
+    _, verts = graph_clrs09_22_6
+    trav = func(None, verts[1], ff_result=lambda v: v.i > 5)
+    trav = set(v.i for v in trav)
+    assert trav == {6, 7, 8, 9}
+
+
+@pytest.mark.parametrize("func", travs)
+def test_dft_ff_via(graph_clrs09_22_6, func):
+    """
+    Ensure the ff_via parameter works on depth-first traversals.
+    """
+    _, verts = graph_clrs09_22_6
+    trav = func(None, verts[1], ff_via=lambda e, v2: v2.i % 2 == 0)
+    trav = set(v.i for v in trav)
+    assert trav == {0, 1, 2, 4, 6, 8}
+
+
+@pytest.mark.parametrize("func", travs)
+def test_dft_ff_via_and_result(graph_clrs09_22_6, func):
+    """
+    Ensure the ff_result *and* ff_via parameter work together on depth-first
+    traversals.
+    """
+    _, verts = graph_clrs09_22_6
+    trav = func(
+        None,
+        verts[1],
+        ff_via=lambda e, v2: v2.i % 2 == 0,
+        ff_result=lambda v: v.i > 5,
+    )
+    trav = set(v.i for v in trav)
+    assert trav == {6, 8}
+
+
 ###############################################################################
 # searches!
 

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -324,6 +324,7 @@ def test_neighbors_filter_func_subclass_directed_backwards():
     Ensure the neighbors() filterfunction works with subclass detection when
     using a backwards link direction.
     """
+
     class VT1(Vertex):
         pass
 
@@ -377,6 +378,7 @@ def test_neighbors_filter_func_subclass_undirected_backwards():
     Ensure the neighbors() filterfunction works with subclass detection when
     using a backwards link direction and an undirected graph.
     """
+
     class VT1(Vertex):
         pass
 

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -60,8 +60,8 @@ def test_neighbors_directed():
     }
     adjlist.load_adj_dict(adj, DirectedEdge)
 
-    v0nb = helpers.neighbors(v[0], direction_sensitive=True)
-    v1nb = helpers.neighbors(v[1], direction_sensitive=True)
+    v0nb = helpers.neighbors(v[0], direction_sensitive=helpers.DIR_SENS_FORWARD)
+    v1nb = helpers.neighbors(v[1], direction_sensitive=helpers.DIR_SENS_FORWARD)
 
     assert v0nb == [v[1]], "v0 neighbors incorrect!"
     assert v1nb == [v[2]], "v1 neighbors incorrect!"
@@ -78,11 +78,37 @@ def test_neighbors_directed_nonsensitive():
     }
     adjlist.load_adj_dict(adj, DirectedEdge)
 
-    v0nb = helpers.neighbors(v[0], direction_sensitive=False)
-    v1nb = helpers.neighbors(v[1], direction_sensitive=False)
+    v0nb = helpers.neighbors(v[0], direction_sensitive=helpers.DIR_SENS_ANY)
+    v1nb = helpers.neighbors(v[1], direction_sensitive=helpers.DIR_SENS_ANY)
 
     assert v0nb == [v[1]], "v0 neighbors incorrect!"
     assert v1nb == [v[0], v[2]], "v1 neighbors incorrect!"
+
+
+def test_neighbors_directed_backwards():
+    """
+    Ensure neighbors function direction sensitivity works backwards.
+    """
+    v = [Vertex(), Vertex(), Vertex(), Vertex()]
+    adj = {
+        v[0]: [v[1]],
+        v[1]: [v[2]],
+    }
+    adjlist.load_adj_dict(adj, DirectedEdge)
+
+    v0nb = helpers.neighbors(
+        v[0], direction_sensitive=helpers.DIR_SENS_BACKWARD
+    )
+    v1nb = helpers.neighbors(
+        v[1], direction_sensitive=helpers.DIR_SENS_BACKWARD
+    )
+    v2nb = helpers.neighbors(
+        v[2], direction_sensitive=helpers.DIR_SENS_BACKWARD
+    )
+
+    assert v0nb == [], "v0 neighbors incorrect!"
+    assert v1nb == [v[0]], "v1 neighbors incorrect!"
+    assert v2nb == [v[1]], "v2 neighbors incorrect!"
 
 
 def test_neighbors_unknown_link_type():
@@ -99,18 +125,52 @@ def test_neighbors_unknown_link_type():
     with pytest.raises(NotImplementedError):
         helpers.neighbors(
             v[0],
-            direction_sensitive=True,
+            direction_sensitive=helpers.DIR_SENS_FORWARD,
             unknown_handling=helpers.LNK_UNKNOWN_ERROR,
         )
 
     v0nb1 = helpers.neighbors(
         v[0],
-        direction_sensitive=True,
+        direction_sensitive=helpers.DIR_SENS_FORWARD,
         unknown_handling=helpers.LNK_UNKNOWN_NEIGHBOR,
     )
     v0nb2 = helpers.neighbors(
         v[0],
-        direction_sensitive=True,
+        direction_sensitive=helpers.DIR_SENS_FORWARD,
+        unknown_handling=helpers.LNK_UNKNOWN_NONNEIGHBOR,
+    )
+
+    assert v0nb1 == [v[1]], "LNK_UNKNOWN_NEIGHBOR behavior wrong!"
+    assert v0nb2 == [], "LNK_UNKNOWN_NONNEIGHBOR behavior wrong!"
+
+
+def test_neighbors_unknown_link_type_backwards():
+    """
+    Ensure neighbors function handles unknown edge types when in backwards
+    mode.
+    """
+    v = [Vertex(), Vertex(), Vertex(), Vertex()]
+    adj = {
+        v[0]: [v[1]],
+        v[1]: [v[2]],
+    }
+    adjlist.load_adj_dict(adj, TwoEndedLink)
+
+    with pytest.raises(NotImplementedError):
+        helpers.neighbors(
+            v[0],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            unknown_handling=helpers.LNK_UNKNOWN_ERROR,
+        )
+
+    v0nb1 = helpers.neighbors(
+        v[0],
+        direction_sensitive=helpers.DIR_SENS_BACKWARD,
+        unknown_handling=helpers.LNK_UNKNOWN_NEIGHBOR,
+    )
+    v0nb2 = helpers.neighbors(
+        v[0],
+        direction_sensitive=helpers.DIR_SENS_BACKWARD,
         unknown_handling=helpers.LNK_UNKNOWN_NONNEIGHBOR,
     )
 
@@ -180,7 +240,9 @@ def test_neighbors_filter_func_subclass_nondirected():
 
     nb1 = set(
         helpers.neighbors(
-            v[0], direction_sensitive=False, filterfunc=filterfunc
+            v[0],
+            direction_sensitive=helpers.DIR_SENS_ANY,
+            filterfunc=filterfunc,
         )
     )
     assert nb1 == {
@@ -192,14 +254,18 @@ def test_neighbors_filter_func_subclass_nondirected():
 
     nb2 = set(
         helpers.neighbors(
-            v[2], direction_sensitive=False, filterfunc=filterfunc
+            v[2],
+            direction_sensitive=helpers.DIR_SENS_ANY,
+            filterfunc=filterfunc,
         )
     )
     assert nb2 == {v[3], v[4], v[5]}, "Neighbors filterfunc gave wrong answer"
 
     nb3 = set(
         helpers.neighbors(
-            v[4], direction_sensitive=False, filterfunc=filterfunc
+            v[4],
+            direction_sensitive=helpers.DIR_SENS_ANY,
+            filterfunc=filterfunc,
         )
     )
     assert nb3 == {v[2], v[3], v[5]}, "Neighbors filterfunc gave wrong answer"
@@ -251,6 +317,115 @@ def test_neighbors_filter_func_subclass_undirected():
         helpers.neighbors(v[4], direction_sensitive=True, filterfunc=filterfunc)
     )
     assert nb3 == {v[2], v[3], v[5]}, "Neighbors filterfunc gave wrong answer"
+
+
+def test_neighbors_filter_func_subclass_directed_backwards():
+    class VT1(Vertex):
+        pass
+
+    class VT2(VT1):
+        pass
+
+    #       0         1        2      3      4     5
+    v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
+    adj = {
+        v[0]: [v[1], v[2], v[4]],
+        v[1]: [v[0], v[2], v[4]],
+        v[2]: [v[0], v[3], v[4]],
+        v[3]: [v[0], v[2], v[4]],
+        v[4]: [v[0], v[2], v[5]],
+        v[5]: [v[0], v[2], v[4]],
+    }
+    adjlist.load_adj_dict(adj, DirectedEdge)
+
+    def filterfunc(e, v2):
+        return isinstance(v2, VT1)
+
+    nb1 = set(
+        helpers.neighbors(
+            v[0],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
+    nb2 = set(
+        helpers.neighbors(
+            v[2],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
+    nb3 = set(
+        helpers.neighbors(
+            v[4],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
+
+    assert nb1 == {v[2], v[3], v[4], v[5]}
+    assert nb2 == {v[3], v[4], v[5]}
+    assert nb3 == {v[2], v[3], v[5]}
+
+
+def test_neighbors_filter_func_subclass_undirected_backwards():
+    class VT1(Vertex):
+        pass
+
+    class VT2(VT1):
+        pass
+
+    #       0         1        2      3      4     5
+    v = [Vertex(), Vertex(), VT1(), VT1(), VT2(), VT2()]
+    adj = {
+        v[0]: [v[1], v[2], v[4]],
+        v[1]: [v[0], v[2], v[4]],
+        v[2]: [v[0], v[3], v[4]],
+        v[3]: [v[0], v[2], v[4]],
+        v[4]: [v[0], v[2], v[5]],
+        v[5]: [v[0], v[2], v[4]],
+    }
+    adjlist.load_adj_dict(adj, UnDirectedEdge)
+
+    def filterfunc(e, v2):
+        return isinstance(v2, VT1)
+
+    nb1 = set(
+        helpers.neighbors(
+            v[0],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
+    nb2 = set(
+        helpers.neighbors(
+            v[2],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
+    nb3 = set(
+        helpers.neighbors(
+            v[4],
+            direction_sensitive=helpers.DIR_SENS_BACKWARD,
+            filterfunc=filterfunc,
+        )
+    )
+
+    assert nb1 == {v[2], v[3], v[4], v[5]}
+    assert nb2 == {v[3], v[4], v[5]}
+    assert nb3 == {v[2], v[3], v[5]}
+
+
+def test_neighbors_bad_directionality(graph_clrs09_22_6):
+    """
+    Ensure an exception is raised when an invalid value is passed to the
+    direction_sensitive argument.
+    """
+
+    _, verts = graph_clrs09_22_6
+    with pytest.raises(ValueError):
+        helpers.neighbors(verts[0], direction_sensitive=-1)
 
 
 def test_findlinks_smoketest():

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -320,6 +320,10 @@ def test_neighbors_filter_func_subclass_undirected():
 
 
 def test_neighbors_filter_func_subclass_directed_backwards():
+    """
+    Ensure the neighbors() filterfunction works with subclass detection when
+    using a backwards link direction.
+    """
     class VT1(Vertex):
         pass
 
@@ -363,12 +367,16 @@ def test_neighbors_filter_func_subclass_directed_backwards():
         )
     )
 
-    assert nb1 == {v[2], v[3], v[4], v[5]}
-    assert nb2 == {v[3], v[4], v[5]}
-    assert nb3 == {v[2], v[3], v[5]}
+    assert nb1 == {v[2], v[3], v[4], v[5]}, "nb1 yielded wrong traversal!"
+    assert nb2 == {v[3], v[4], v[5]}, "nb2 yielded wrong traversal!"
+    assert nb3 == {v[2], v[3], v[5]}, "nb3 yielded wrong traversal!"
 
 
 def test_neighbors_filter_func_subclass_undirected_backwards():
+    """
+    Ensure the neighbors() filterfunction works with subclass detection when
+    using a backwards link direction and an undirected graph.
+    """
     class VT1(Vertex):
         pass
 
@@ -412,9 +420,9 @@ def test_neighbors_filter_func_subclass_undirected_backwards():
         )
     )
 
-    assert nb1 == {v[2], v[3], v[4], v[5]}
-    assert nb2 == {v[3], v[4], v[5]}
-    assert nb3 == {v[2], v[3], v[5]}
+    assert nb1 == {v[2], v[3], v[4], v[5]}, "nb1 yielded wrong traversal!"
+    assert nb2 == {v[3], v[4], v[5]}, "nb2 yielded wrong traversal!"
+    assert nb3 == {v[2], v[3], v[5]}, "nb3 yielded wrong traversal!"
 
 
 def test_neighbors_bad_directionality(graph_clrs09_22_6):


### PR DESCRIPTION
New in 0.6.0:

- Backwards traversal options for depth- and breadth-first traversals
- Improved during-traversal filtering options for the same
- Graph deconstruction utilities (link removal, vertex removal from universe, etc)
- Pyvis outputs default to local CDN resources
- Semi-singletons can have multiple mappings