### PR TITLE
Improve semi-singleton utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ prof
 # developer mental sanity tracker
 TODO.md
 .tmux-startup.sh
+.python-version
 
 # distributon files
 dist/

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -416,14 +416,14 @@ def check_semi_singleton_entry_exists(cls: type, identifier: Hashable):
        document this
     """
     # get the real semisingleton metaclass, not just the user type
-    sstype = type(cls)
+    mcls = type(cls)
 
     # use the metaclass's hash function to identify the primary key
-    hashfunc = cls._SemiSingleton__semisingleton_hashfunc
+    hashfunc = mcls._SemiSingleton__semisingleton_hashfunc
     hashid = hashfunc(*identifier)
 
-    if hashid in sstype._SemiSingleton__semisingleton_instance_map:
-        return sstype._SemiSingleton__semisingleton_instance_map[hashid]
+    if hashid in mcls._SemiSingleton__semisingleton_instance_map:
+        return mcls._SemiSingleton__semisingleton_instance_map[hashid]
 
     return None
 

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -393,27 +393,53 @@ def add_mapping(identifier: Hashable, obj: object):
     cls._SemiSingleton__semisingleton_instance_map[hashid] = obj
 
 
-def drop_semi_singleton_mapping(identifier: Hashable, obj: object):
+def drop_semi_singleton_mapping(cls: type, identifier: Hashable):
     """
-    .. todo::
+    Remove an mapping from the specified semi-singleton instance.
 
-       document this
+    This removes a *single* mapping of a key to instance.  It may be considered
+    removing a semisingleton instance, though if multiple mappings exist to
+    single instance, it will still be accessible by other remaining
+    identifiers.
+
+    .. seealso::
+
+       * :py:func:`clear_semi_singleton`, a clear-all operation instead of this
+         clear-one
+
+    :param cls: Class to remove the mapping from.  This is typically thought of
+      as ``type(some_object)``.
+    :param identifier: Two-tuple of arguments and keyword arguments that will
+      be passed to the class's ``__init__`` method.  Typically, the first
+      element is another tuple representing positional arguments, and the
+      second element is a dictionary representing keyword arguments.
     """
     # get the metaclass type
-    cls = type(type(obj))
+    mcls = type(cls)
 
     # use the metaclass's hash function to identify the primary key
-    hashfunc = cls._SemiSingleton__semisingleton_hashfunc
+    hashfunc = mcls._SemiSingleton__semisingleton_hashfunc
     hashid = hashfunc(*identifier)
 
-    del cls._SemiSingleton__semisingleton_instance_map[hashid]
+    del mcls._SemiSingleton__semisingleton_instance_map[hashid]
 
 
-def check_semi_singleton_entry_exists(cls: type, identifier: Hashable):
+def check_semi_singleton_entry_exists(cls: type, identifier: Hashable) -> object:
     """
-    .. todo::
+    Test whether a semisingleton exists for the given mapping without creating
+    it.
 
-       document this
+    This function allows checking whether a semisingleton instance exists for
+    the provided identifier, without creating it if it does not exist.
+
+    :param cls: Class to test.  This is typically thought of as
+      ``type(some_object)``.
+    :param identifier: Two-tuple of arguments and keyword arguments that will
+      be passed to the class's ``__init__`` method.  Typically, the first
+      element is another tuple representing positional arguments, and the
+      second element is a dictionary representing keyword arguments.
+    :return: The instance accessible via the given mapping if such exists; else
+      ``None``.
     """
     # get the real semisingleton metaclass, not just the user type
     mcls = type(cls)

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -489,6 +489,7 @@ def check_semi_singleton_entry_exists(cls: type, *args, **kwargs) -> object:
 
     return None
 
+
 def get_all_semi_singleton_instances(cls: type) -> Generator[object]:
     """
     Get all instances belonging to a given semi-singleton type.
@@ -555,5 +556,3 @@ def clear_semi_singleton(cls: type) -> None:
     :param cls: Class to clear semisingleton states from.
     """
     type(cls)._SemiSingleton__semisingleton_instance_map = {}
-
-

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -393,6 +393,40 @@ def add_mapping(identifier: Hashable, obj: object):
     cls._SemiSingleton__semisingleton_instance_map[hashid] = obj
 
 
+def drop_semi_singleton_mapping(identifier: Hashable, obj: object):
+    """
+    .. todo::
+
+       document this
+    """
+    # get the metaclass type
+    cls = type(type(obj))
+
+    # use the metaclass's hash function to identify the primary key
+    hashfunc = cls._SemiSingleton__semisingleton_hashfunc
+    hashid = hashfunc(*identifier)
+
+    del cls._SemiSingleton__semisingleton_instance_map[hashid]
+
+
+def check_semi_singleton_entry_exists(cls: type, identifier: Hashable):
+    """
+    .. todo::
+
+       document this
+    """
+    # get the real semisingleton metaclass, not just the user type
+    sstype = type(cls)
+
+    # use the metaclass's hash function to identify the primary key
+    hashfunc = cls._SemiSingleton__semisingleton_hashfunc
+    hashid = hashfunc(*identifier)
+
+    if hashid in sstype._SemiSingleton__semisingleton_instance_map:
+        return sstype._SemiSingleton__semisingleton_instance_map[hashid]
+
+    return None
+
 def get_all_semi_singleton_instances(cls: type) -> Generator[object]:
     """
     Get all instances belonging to a given semi-singleton type.
@@ -459,3 +493,5 @@ def clear_semi_singleton(cls: type) -> None:
     :param cls: Class to clear semisingleton states from.
     """
     type(cls)._SemiSingleton__semisingleton_instance_map = {}
+
+

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -343,7 +343,7 @@ def semi_singleton_metaclass(hashfunc: Callable = None) -> type:
     return _SemiSingleton
 
 
-def add_mapping(identifier: Hashable, obj: object):
+def add_mapping(obj: object, *args, **kwargs):
     """
     Adds another mapping to a semi-singleton instance.
 
@@ -366,20 +366,20 @@ def add_mapping(identifier: Hashable, obj: object):
     <__main__.SemiSingleton object at 0x01234567>
     >>> s2 is s3
     False
-    >>> add_mapping(((39,), {'bar': True}), s3)
+    >>> add_mapping(s3, 39, bar=True)
     >>> s4 = SemiSingleton(39, True)  # we get s3 again, despite different args
     >>> s4
     <__main__.SemiSingleton object at 0x01234567>
     >>> s3 is s4
     True
 
-    :param identifier: Two-tuple of arguments and keyword arguments that will
-      be passed to the class's ``__init__`` method.  Typically, the first
-      element is another tuple representing positional arguments, and the
-      second elemtn is a dictionary representing keyword arguments.
     :param obj: The object to map the extra identifier to.  Henceforth after
       this function, this object will be reachable by the identifier given as
       well as any others it may have already had.
+    :param \\*args: Positional arguments as would normally be passed to the
+      semi-singleton class instantiation.
+    :param \\**kwargs: Positional arguments as would normally be passed to the
+      semi-singleton class instantiation.
     """
     # get the metaclass type
     cls = type(type(obj))
@@ -387,13 +387,13 @@ def add_mapping(identifier: Hashable, obj: object):
     # use the metaclass's hash function to line up with existing / future
     # mappings
     hashfunc = cls._SemiSingleton__semisingleton_hashfunc
-    hashid = hashfunc(*identifier)
+    hashid = hashfunc(args, kwargs)
 
     # store the hashed identifier in the metaclass map of hashes to instances
     cls._SemiSingleton__semisingleton_instance_map[hashid] = obj
 
 
-def drop_semi_singleton_mapping(cls: type, identifier: Hashable):
+def drop_semi_singleton_mapping(cls: type, *args, **kwargs):
     """
     Remove an mapping from the specified semi-singleton instance.
 
@@ -407,24 +407,43 @@ def drop_semi_singleton_mapping(cls: type, identifier: Hashable):
        * :py:func:`clear_semi_singleton`, a clear-all operation instead of this
          clear-one
 
+    >>> from edgegraph.singleton import semi_singleton_metaclass, \\
+            drop_semi_singleton_mapping
+    >>> class SemiSingleton(metaclass=semi_singleton_metaclass()):
+    ...     def __init__(self, foo, bar=False):
+    ...         self.foo = foo
+    ...         self.bar = bar
+    ...
+    >>> s3 = SemiSingleton(37, True)  # different arguments -- different object
+    >>> s3
+    <__main__.SemiSingleton object at 0x01234567>
+    >>> s4 = SemiSingleton(4)
+    >>> s5 = SemiSingleton(5)
+    >>> drop_semi_singleton_mapping(SemiSingleton, 4)  # drop s4
+    >>> s4_2 = SemiSingleton(4)  # will now return a new instance
+    >>> s4 is s4_2
+    False
+    >>> SemiSingleton(5) is s5  # other mappings unaffected
+    True
+
     :param cls: Class to remove the mapping from.  This is typically thought of
       as ``type(some_object)``.
-    :param identifier: Two-tuple of arguments and keyword arguments that will
-      be passed to the class's ``__init__`` method.  Typically, the first
-      element is another tuple representing positional arguments, and the
-      second element is a dictionary representing keyword arguments.
+    :param \\*args: Positional arguments as would normally be passed to the
+      semi-singleton class instantiation.
+    :param \\**kwargs: Positional arguments as would normally be passed to the
+      semi-singleton class instantiation.
     """
     # get the metaclass type
     mcls = type(cls)
 
     # use the metaclass's hash function to identify the primary key
     hashfunc = mcls._SemiSingleton__semisingleton_hashfunc
-    hashid = hashfunc(*identifier)
+    hashid = hashfunc(args, kwargs)
 
     del mcls._SemiSingleton__semisingleton_instance_map[hashid]
 
 
-def check_semi_singleton_entry_exists(cls: type, identifier: Hashable) -> object:
+def check_semi_singleton_entry_exists(cls: type, *args, **kwargs) -> object:
     """
     Test whether a semisingleton exists for the given mapping without creating
     it.
@@ -432,12 +451,29 @@ def check_semi_singleton_entry_exists(cls: type, identifier: Hashable) -> object
     This function allows checking whether a semisingleton instance exists for
     the provided identifier, without creating it if it does not exist.
 
+    >>> from edgegraph.singleton import semi_singleton_metaclass, \\
+            check_semi_singleton_entry_exists
+    >>> class SemiSingleton(metaclass=semi_singleton_metaclass()):
+    ...     def __init__(self, foo, bar=False):
+    ...         self.foo = foo
+    ...         self.bar = bar
+    ...
+    >>> s3 = SemiSingleton(37, True)  # different arguments -- different object
+    >>> s3
+    <__main__.SemiSingleton object at 0x01234567>
+    >>> # object exists; it will be returned, but unaffected
+    >>> check_semi_singleton_entry_exists(SemiSingleton, 37, bar=True)
+    <__main__.SemiSingleton object at 0x01234567>
+    >>> # object does not exist; None returned, such an object is *not* created
+    >>> check_semi_singleton_entry_exists(128)
+    >>>
+
     :param cls: Class to test.  This is typically thought of as
       ``type(some_object)``.
-    :param identifier: Two-tuple of arguments and keyword arguments that will
-      be passed to the class's ``__init__`` method.  Typically, the first
-      element is another tuple representing positional arguments, and the
-      second element is a dictionary representing keyword arguments.
+    :param \\*args: Positional arguments as would normally be passed to the
+      semi-singleton class instantiation.
+    :param \\**kwargs: Positional arguments as would normally be passed to the
+      semi-singleton class instantiation.
     :return: The instance accessible via the given mapping if such exists; else
       ``None``.
     """
@@ -446,7 +482,7 @@ def check_semi_singleton_entry_exists(cls: type, identifier: Hashable) -> object
 
     # use the metaclass's hash function to identify the primary key
     hashfunc = mcls._SemiSingleton__semisingleton_hashfunc
-    hashid = hashfunc(*identifier)
+    hashid = hashfunc(args, kwargs)
 
     if hashid in mcls._SemiSingleton__semisingleton_instance_map:
         return mcls._SemiSingleton__semisingleton_instance_map[hashid]

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -537,6 +537,7 @@ def test_semi_singleton_drop_single_mapping():
     Ensure we can drop a single semisingleton mapping without nuking everything
     else.
     """
+
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -559,6 +560,7 @@ def test_semi_singleton_check_mapping():
     """
     Ensure we can *check* for a semisingleton instance without creating one.
     """
+
     class A(metaclass=singleton.semi_singleton_metaclass()):
         def __init__(self, *args):
             self.args = args
@@ -578,7 +580,3 @@ def test_semi_singleton_check_mapping():
     assert singleton.check_semi_singleton_entry_exists(B, 2) is b2
     assert singleton.check_semi_singleton_entry_exists(A, 3) is None
     assert singleton.check_semi_singleton_entry_exists(B, 4) is None
-
-
-
-

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -471,7 +471,7 @@ def test_semi_singleton_multiname_smoketest():
     a1 = A(1)
     a2 = A(2)
 
-    singleton.add_mapping(((3,), {}), a2)
+    singleton.add_mapping(a2, 3)
 
     a3 = A(3)
 
@@ -502,7 +502,7 @@ def test_semi_singleton_multiname_no_crosscontamination():
     assert b1 is not b2, "pre add_mapping() bad setup!"
     assert a2 is not b2, "pre add_mapping() bad setup!"
 
-    singleton.add_mapping(((3,), {}), a2)
+    singleton.add_mapping(a2, 3)
 
     a3 = A(3)
     b3 = B(3)
@@ -525,7 +525,7 @@ def test_semi_singleton_multiname_multiple():
     a2 = A(2)
 
     for i in range(100):
-        singleton.add_mapping(((i,), {}), a2)
+        singleton.add_mapping(a2, i)
         ai = A(i)
 
         assert ai is a2, f"add_mapping() failed mult-test at {i}!"
@@ -550,9 +550,9 @@ def test_semi_singleton_drop_single_mapping():
     b1 = B(1)
     b2 = B(2)
 
-    singleton.drop_semi_singleton_mapping(A, ((1,), {}))
+    singleton.drop_semi_singleton_mapping(A, 1)
 
-    assert singleton.check_semi_singleton_entry_exists(A, ((1,), {})) is None
+    assert singleton.check_semi_singleton_entry_exists(A, 1) is None
 
 
 def test_semi_singleton_check_mapping():
@@ -572,12 +572,12 @@ def test_semi_singleton_check_mapping():
     b1 = B(1)
     b2 = B(2)
 
-    assert singleton.check_semi_singleton_entry_exists(A, ((1,), {})) is a1
-    assert singleton.check_semi_singleton_entry_exists(A, ((2,), {})) is a2
-    assert singleton.check_semi_singleton_entry_exists(B, ((1,), {})) is b1
-    assert singleton.check_semi_singleton_entry_exists(B, ((2,), {})) is b2
-    assert singleton.check_semi_singleton_entry_exists(A, ((3,), {})) is None
-    assert singleton.check_semi_singleton_entry_exists(B, ((4,), {})) is None
+    assert singleton.check_semi_singleton_entry_exists(A, 1) is a1
+    assert singleton.check_semi_singleton_entry_exists(A, 2) is a2
+    assert singleton.check_semi_singleton_entry_exists(B, 1) is b1
+    assert singleton.check_semi_singleton_entry_exists(B, 2) is b2
+    assert singleton.check_semi_singleton_entry_exists(A, 3) is None
+    assert singleton.check_semi_singleton_entry_exists(B, 4) is None
 
 
 

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -550,7 +550,7 @@ def test_semi_singleton_drop_single_mapping():
     b1 = B(1)
     b2 = B(2)
 
-    singleton.drop_semi_singleton_mapping(((1,), {}), a1)
+    singleton.drop_semi_singleton_mapping(A, ((1,), {}))
 
     assert singleton.check_semi_singleton_entry_exists(A, ((1,), {})) is None
 

--- a/tests/structure/test_singleton.py
+++ b/tests/structure/test_singleton.py
@@ -530,3 +530,55 @@ def test_semi_singleton_multiname_multiple():
 
         assert ai is a2, f"add_mapping() failed mult-test at {i}!"
         assert ai is not a1, f"add_mapping() side effect at {i}!"
+
+
+def test_semi_singleton_drop_single_mapping():
+    """
+    Ensure we can drop a single semisingleton mapping without nuking everything
+    else.
+    """
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    class B(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+    b1 = B(1)
+    b2 = B(2)
+
+    singleton.drop_semi_singleton_mapping(((1,), {}), a1)
+
+    assert singleton.check_semi_singleton_entry_exists(A, ((1,), {})) is None
+
+
+def test_semi_singleton_check_mapping():
+    """
+    Ensure we can *check* for a semisingleton instance without creating one.
+    """
+    class A(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    class B(metaclass=singleton.semi_singleton_metaclass()):
+        def __init__(self, *args):
+            self.args = args
+
+    a1 = A(1)
+    a2 = A(2)
+    b1 = B(1)
+    b2 = B(2)
+
+    assert singleton.check_semi_singleton_entry_exists(A, ((1,), {})) is a1
+    assert singleton.check_semi_singleton_entry_exists(A, ((2,), {})) is a2
+    assert singleton.check_semi_singleton_entry_exists(B, ((1,), {})) is b1
+    assert singleton.check_semi_singleton_entry_exists(B, ((2,), {})) is b2
+    assert singleton.check_semi_singleton_entry_exists(A, ((3,), {})) is None
+    assert singleton.check_semi_singleton_entry_exists(B, ((4,), {})) is None
+
+
+
+


### PR DESCRIPTION
This PR adds the following utilities for working with semi-singletons:

1. `drop_semi_singleton_mapping`, for removing a single link in the semisingleton instance mapping
2. `check_semi_singleton_entry_exists`, for seeing if a given mapping exists without creating it

it also changes the call signature of `add_mapping` to improve cleanliness and code quality (!! **WARNING** !! This breaks backwards comparability!)

When merged, fixes #52.