### PR TITLE
Optional dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,8 +26,7 @@ jobs:
         sudo apt update
         sudo apt install plantuml
         python -m pip install --upgrade pip
-        pip install -r scripts/test-requirements.txt
-        pip install -r scripts/docs-requirements.txt
+        pip install .[development]
 
     - name: Documentation coverage
       if: ${{ matrix.python-version == '3.12' }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,7 +30,11 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# and https://docs.readthedocs.io/en/stable/config-file/v2.html#packages
 python:
    install:
-   - requirements: scripts/docs-requirements.txt
+     - method: pip
+       path: .
+       extra_requirements:
+         - development
 

--- a/docs/developer/70-documentation.rst
+++ b/docs/developer/70-documentation.rst
@@ -21,7 +21,7 @@ Documentation can be built locally using the Sphinx makefile in the
 :file:`docs/` folder.  Ensure you have the following prerequisites:
 
 #. PlantUML installed (see https://plantuml.com/ )
-#. Pip prerequisites: :samp:`pip install -r scripts/docs-requirements.txt`)
+#. Pip prerequisites: :samp:`pip install .[development]`
 
 Then, simply run :samp:`make clean html` to build docs locally.  Output will be
 placed in :file:`docs/_build/`.  You may also inspect the output of :samp:`make

--- a/docs/usage/00-installation.rst
+++ b/docs/usage/00-installation.rst
@@ -10,6 +10,20 @@ Installation of EdgeGraph is rather simple via Pip:
 Details of the Pip package can be found on Pip at
 https://pypi.org/project/edgegraph/ .
 
+.. _install/extras:
+
+Extras
+------
+
+Edgegraph's pip definition contains some optional extra components:
+
+* :samp:`$ pip install edgegraph[foreign]` for all the foreign Python modules
+  edgegraph can interface with
+* :samp:`$ pip install edgegraph[full]` for all the above options
+* :samp:`$ pip install edgegraph[development]` for the full devops packages
+  needed to develop, test, document, build, and publish edgegraph itself (this
+  includes `edgegraph[full]`)
+
 .. _versioning:
 
 Versioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,41 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+[project.optional-dependencies]
+foreign = [
+    "pyvis"
+]
+full = [
+    "edgegraph[foreign]"
+]
+development = [
+    # documentation dependencies
+    "sphinxcontrib-plantuml",
+    "sphinx-copybutton",
+    "sphinx-book-theme",
+    "myst-parser",
+    "tomlkit",
+
+    # test dependencies
+    "pytest",
+    "coverage",
+    "pytest-cov",
+    "pytest-profiling",
+
+    # code quality control
+    # pylint is also needed for documentation
+    "pylint",
+    "black",
+    "mypy",
+
+    # build & upload to pypi dependencies
+    "build",
+    "twine",
+
+    # and everything else
+    "edgegraph[full]"
+]
+
 [project.urls]
 Homepage = "https://edgegraph.readthedocs.io/en/latest/"
 Repository = "https://github.com/mishaturnbull/edgegraph"

--- a/scripts/docs-requirements.txt
+++ b/scripts/docs-requirements.txt
@@ -1,9 +1,0 @@
-sphinxcontrib-plantuml
-sphinx-copybutton
-sphinx-book-theme
-myst-parser
-tomlkit
-pylint
-pytest
-pyvis
-

--- a/scripts/pypi.sh
+++ b/scripts/pypi.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-if [ -e dist ]
+if [ -z "$1" ]
 then
-    rm -rf dist
+    echo "Must specify an argument; can be 'real' or 'test'."
+    exit 1
 fi
 
 if [ -e lib ]
@@ -45,6 +46,26 @@ echo "before uploading; use ctrl-C to interrupt.  The following files will"
 echo "be uploaded:"
 echo
 ls -lh dist
+
+echo
+echo
+if [ $1 = "real" ]
+then
+    echo "+-----------------------------------------------------------+"
+    echo "| +-------------------------------------------------------+ |"
+    echo "| | These files will be uploaded to the REAL PyPI repo!!! | |"
+    echo "| +-------------------------------------------------------+ |"
+    echo "+-----------------------------------------------------------+"
+
+elif [ $1 = "test" ]
+then
+    echo "These files will be uploaded to the testing PyPi repo."
+else
+    echo "Unrecognized repository specifier '$1'; aborting."
+    echo "Valid options are 'real' or 'test'."
+    exit 1
+fi
+
 echo
 echo
 (
@@ -59,5 +80,11 @@ echo
 echo "Beginning upload!!"
 echo
 
-python -m twine upload dist/*
+if [ $1 = "real" ]
+then
+    python -m twine upload dist/*
+elif [ $1 = "test" ]
+then
+    python -m twine upload --repository testpypi dist/*
+fi
 

--- a/scripts/test-requirements.txt
+++ b/scripts/test-requirements.txt
@@ -1,9 +1,0 @@
-pylint
-pytest
-coverage
-pytest-cov
-pytest-profiling
-pyvis
-black
-mypy
-


### PR DESCRIPTION
This adds optional dependency specifiers to pyproject.toml, such that `pip install edgegraph[...]` is possible.  For testing purposes, the pypi upload script has also been buffed to allow uploading to testpypi repo.

Before merge:
* [x] Update installation docs
* [x] Update development docs to note `pip install .[development]` approach
* [x] Remove `scripts/*-dependencies.txt` reqs files