### PR TITLE
Replace Optional[x] with x | None

### DIFF
--- a/edgegraph/builder/explicit.py
+++ b/edgegraph/builder/explicit.py
@@ -16,7 +16,7 @@ functions will get the necessary updates to match, and the API stays unchanged.
 
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from edgegraph.structure import (
     Vertex,
     DirectedEdge,
@@ -64,7 +64,7 @@ def link_from_to(
     return lnktype(v1, v2)
 
 
-def unlink(v1: Vertex, v2: Vertex, destroy=True) -> Optional[set[TwoEndedLink]]:
+def unlink(v1: Vertex, v2: Vertex, destroy=True) -> set[TwoEndedLink] | None:
     """
     Remive all links between ``v1`` and ``v2``.
 

--- a/edgegraph/builder/randgraph.py
+++ b/edgegraph/builder/randgraph.py
@@ -8,7 +8,6 @@ Procedures for creating random graphs.
 from __future__ import annotations
 
 import random
-from typing import Optional
 from edgegraph.structure import Vertex, DirectedEdge, Universe
 from edgegraph.builder import adjlist
 
@@ -16,8 +15,8 @@ from edgegraph.builder import adjlist
 def randgraph(
     count: int = 15,
     edge: type = DirectedEdge,
-    connectivity: Optional[float] = None,
-    ensurelink: Optional[bool] = True,
+    connectivity: float | None = None,
+    ensurelink: bool | None = True,
 ) -> Universe:
     """
     Create a random graph.

--- a/edgegraph/output/plaintext.py
+++ b/edgegraph/output/plaintext.py
@@ -17,7 +17,6 @@ formats may be added in the future.
 """
 
 from __future__ import annotations
-from typing import Optional
 from collections.abc import Callable
 from edgegraph.structure import Universe
 from edgegraph.traversal import helpers
@@ -25,9 +24,9 @@ from edgegraph.traversal import helpers
 
 def basic_render(
     uni: Universe,
-    rfunc: Optional[Callable] = None,
-    sort: Optional[Callable] = None,
-) -> Optional[str]:
+    rfunc: Callable | None = None,
+    sort: Callable | None = None,
+) -> str | None:
     """
     Perform a very basic rendering of a graph into a string.
 

--- a/edgegraph/output/plantuml.py
+++ b/edgegraph/output/plantuml.py
@@ -64,7 +64,6 @@ import subprocess
 import shutil
 import tempfile
 import datetime
-from typing import Optional
 
 from edgegraph.structure import Universe, Vertex, DirectedEdge, UnDirectedEdge
 
@@ -282,7 +281,7 @@ def _one_vert_to_skinparam(vert, options):
     return output
 
 
-def render_to_plantuml_src(uni: Universe, options: dict) -> Optional[str]:
+def render_to_plantuml_src(uni: Universe, options: dict) -> str | None:
     """
     Render a universe to PlantUML source.
 

--- a/edgegraph/output/pyvis.py
+++ b/edgegraph/output/pyvis.py
@@ -39,7 +39,7 @@ Generally, the usage pattern for this module is intended to be as:
 
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 try:
@@ -65,9 +65,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def make_pyvis_net(
     uni: Universe,
-    rvfunc: Optional[Callable] = None,
-    refunc: Optional[Callable] = None,
-    network_kwargs: Optional[dict] = None,
+    rvfunc: Callable | None = None,
+    refunc: Callable | None = None,
+    network_kwargs: dict = None,
 ) -> pyvis.network.Network:
     """
     Convert a given Universe to a PyVis network, suitable for further use
@@ -169,9 +169,9 @@ def make_pyvis_net(
 
 def pyvis_render_customizable(
     uni: Universe,
-    rvfunc: Optional[Callable] = None,
-    refunc: Optional[Callable] = None,
-    show_buttons_filter: Optional[dict[str, str]] = None,
+    rvfunc: Callable | None = None,
+    refunc: Callable | None = None,
+    show_buttons_filter: dict[str, str] | None = None,
 ) -> pyvis.network.Network:
     """
     Convert a given Universe to a PyVis network, suitable for further use

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -6,7 +6,7 @@ Contains the BaseObject class.
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 import uuid
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -52,11 +52,9 @@ class BaseObject(object):
     def __init__(
         self,
         *,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
-        # WHY does this work??  __future__ annotations??  Universe isn't
-        # imported!!
-        universes: Optional[set[Universe]] = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
+        universes: set[Universe] | None = None,
     ):
         """
         Instantiate a BaseObject.

--- a/edgegraph/structure/directededge.py
+++ b/edgegraph/structure/directededge.py
@@ -6,7 +6,7 @@ Holds the DirectedEdge class.
 """
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from edgegraph.structure import twoendedlink
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -29,11 +29,11 @@ class DirectedEdge(twoendedlink.TwoEndedLink):
 
     def __init__(
         self,
-        v1: Optional[Vertex] = None,
-        v2: Optional[Vertex] = None,
+        v1: Vertex | None = None,
+        v2: Vertex | None = None,
         *,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
     ):
         """
         Instantiate a directed edge.

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -6,7 +6,7 @@ Holds the Link class.
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from edgegraph.structure import base
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -35,10 +35,10 @@ class Link(base.BaseObject):
     def __init__(
         self,
         *,
-        vertices: Optional[list[Vertex]] = None,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
-        _force_creation: Optional[bool] = False,
+        vertices: list[Vertex] | None = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
+        _force_creation: bool | None = False,
     ):
         """
         Instantiate a new link ("edge").

--- a/edgegraph/structure/singleton.py
+++ b/edgegraph/structure/singleton.py
@@ -39,7 +39,6 @@ after some surveying (Googling) I decided that metaclasses approach gave:
 """
 
 from __future__ import annotations
-from typing import Optional
 from collections.abc import Generator, Callable, Hashable
 
 import json
@@ -146,7 +145,7 @@ class TrueSingleton(type):
         return cls._TrueSingleton__singleton_instances[cls]
 
 
-def clear_true_singleton(cls: Optional[type] = None) -> None:
+def clear_true_singleton(cls: type | None = None) -> None:
     """
     Clears TrueSingleton cache for either a specified type, or all
     TrueSingleton types.
@@ -209,7 +208,7 @@ def clear_true_singleton(cls: Optional[type] = None) -> None:
 # what this function actually does isn't complex, in *theory*.  however,
 # metaclass hacking is some of the deeper black magic of Python -- so document
 # the crap out of it.
-def semi_singleton_metaclass(hashfunc: Optional[Callable] = None) -> type:
+def semi_singleton_metaclass(hashfunc: Callable | None = None) -> type:
     """
     Generate and return a metaclass for semi-singletons.
 

--- a/edgegraph/structure/twoendedlink.py
+++ b/edgegraph/structure/twoendedlink.py
@@ -6,7 +6,7 @@ Holds the TwoEndedLink class.
 """
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from edgegraph.structure import link, vertex
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -29,11 +29,11 @@ class TwoEndedLink(link.Link):
 
     def __init__(
         self,
-        v1: Optional[Vertex] = None,
-        v2: Optional[Vertex] = None,
+        v1: Vertex | None = None,
+        v2: Vertex | None = None,
         *,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
     ):
         """
         Instantiate an two-ended edge.
@@ -120,7 +120,7 @@ class TwoEndedLink(link.Link):
         self._vertices = [v1]
         self.add_vertex(new)
 
-    def other(self, end: Vertex) -> Optional[Vertex]:
+    def other(self, end: Vertex) -> Vertex | None:
         """
         Identify and return the other end of this edge.
 

--- a/edgegraph/structure/undirectededge.py
+++ b/edgegraph/structure/undirectededge.py
@@ -6,7 +6,7 @@ Holds the UnDirectedEdge class.
 """
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from edgegraph.structure import twoendedlink
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -36,11 +36,11 @@ class UnDirectedEdge(twoendedlink.TwoEndedLink):
     # pylint: disable-next=useless-parent-delegation
     def __init__(
         self,
-        v1: Optional[Vertex] = None,
-        v2: Optional[Vertex] = None,
+        v1: Vertex | None = None,
+        v2: Vertex | None = None,
         *,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
     ):
         """
         Instantiate an undirected edge.

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -6,7 +6,7 @@ Holds the Universe class.
 """
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import types
 from edgegraph.structure import base, vertex
 
@@ -37,12 +37,12 @@ class UniverseLaws(base.BaseObject):
 
     def __init__(
         self,
-        edge_whitelist: Optional[dict] = None,
+        edge_whitelist: dict | None = None,
         mixed_links: bool = False,
         cycles: bool = True,
         multipath: bool = True,
         multiverse: bool = False,
-        applies_to: Optional[Universe] = None,
+        applies_to: Universe | None = None,
     ):
         """
         Instantiate a set of universal laws.
@@ -139,7 +139,7 @@ class UniverseLaws(base.BaseObject):
         return self._multiverse
 
     @property
-    def applies_to(self) -> Optional[Universe]:
+    def applies_to(self) -> Universe | None:
         """
         Returns the universe that these laws apply to.
         """
@@ -184,10 +184,10 @@ class Universe(vertex.Vertex):
     def __init__(
         self,
         *,
-        vertices: Optional[set[vertex.Vertex]] = None,
-        laws: Optional[UniverseLaws] = None,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
+        vertices: set[vertex.Vertex] | None = None,
+        laws: UniverseLaws | None = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
     ):
         """
         Instantiate a Universe.
@@ -203,7 +203,7 @@ class Universe(vertex.Vertex):
         super().__init__(uid=uid, attributes=attributes)
 
         #: Laws of the universe
-        self._laws: Optional[UniverseLaws] = laws
+        self._laws: UniverseLaws | None = laws
         if self._laws is None:
             self._laws = UniverseLaws(applies_to=self)
         self._laws.applies_to = self
@@ -251,7 +251,7 @@ class Universe(vertex.Vertex):
             vert.remove_from_universe(self)
 
     @property
-    def laws(self) -> Optional[UniverseLaws]:
+    def laws(self) -> UniverseLaws | None:
         """
         Get the laws of this universe.
         """

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -6,7 +6,7 @@ Holds the Vertex class.
 """
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from edgegraph.structure import base
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -77,10 +77,10 @@ class Vertex(base.BaseObject):
     def __init__(
         self,
         *,
-        links: Optional[list[Link]] = None,
-        uid: Optional[int] = None,
-        attributes: Optional[dict] = None,
-        universes: Optional[set[Universe]] = None,
+        links: list[Link] | None = None,
+        uid: int | None = None,
+        attributes: dict | None = None,
+        universes: set[Universe] | None = None,
     ):
         """
         Creates a new vertex.

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -49,7 +49,6 @@ visiting v9 before v10) is determined by the structure of the universe.
 from __future__ import annotations
 
 import collections
-from typing import Optional
 from collections.abc import Callable
 
 from edgegraph.structure import Universe, Vertex
@@ -60,7 +59,7 @@ from edgegraph.traversal import helpers
 
 def bfs(
     uni: Universe, start: Vertex, attrib: str, val: object
-) -> Optional[Vertex]:
+) -> Vertex | None:
     """
     Perform a breadth-first search.
 
@@ -116,9 +115,9 @@ def bft(
     start: Vertex,
     direction_sensitive: int = helpers.DIR_SENS_FORWARD,
     unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
-    ff_via: Optional[Callable] = None,
-    ff_result: Optional[Callable] = None,
-) -> Optional[list[Vertex]]:
+    ff_via: Callable | None = None,
+    ff_result: Callable | None = None,
+) -> list[Vertex] | None:
     """
     Perform a breadth-first traversal.
 

--- a/edgegraph/traversal/depthfirst.py
+++ b/edgegraph/traversal/depthfirst.py
@@ -51,7 +51,6 @@ visiting v3 before v6) is determined by the structure of the universe.
 """
 
 from __future__ import annotations
-from typing import Optional
 from collections.abc import Callable
 from edgegraph.structure import Universe, Vertex
 from edgegraph.traversal import helpers
@@ -79,8 +78,8 @@ def _dft_recur(
     visited: dict[Vertex, None],
     direction_sensitive: int,
     unknown_handling: int,
-    ff_via: Optional[Callable] = None,
-    ff_result: Optional[Callable] = None,
+    ff_via: Callable | None = None,
+    ff_result: Callable | None = None,
 ) -> list[Vertex]:
     """
     Recursion helper for :py:func:`dft_recursive`.  For internal use only!
@@ -126,8 +125,8 @@ def dft_recursive(
     start: Vertex,
     direction_sensitive: int = helpers.DIR_SENS_FORWARD,
     unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
-    ff_via: Optional[Callable] = None,
-    ff_result: Optional[Callable] = None,
+    ff_via: Callable | None = None,
+    ff_result: Callable | None = None,
 ) -> list[Vertex]:
     """
     Perform a recursive depth-first traversal of the given universe, starting
@@ -165,7 +164,7 @@ def _dfs_recur(
     visited: dict[Vertex, None],
     attrib: str,
     val: object,
-) -> Optional[Vertex]:
+) -> Vertex | None:
     """
     Recursion helper for :py:func:`dfs_recursive`.  For internal use only!
 
@@ -196,7 +195,7 @@ def _dfs_recur(
 
 def dfs_recursive(
     uni: Universe, start: Vertex, attrib: str, val: object
-) -> Optional[Vertex]:
+) -> Vertex | None:
     """
     Perform a recursive depth-first search in the given graph for a given
     attribute.
@@ -238,8 +237,8 @@ def dft_iterative(
     start: Vertex,
     direction_sensitive: int = helpers.DIR_SENS_FORWARD,
     unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
-    ff_via: Optional[Callable] = None,
-    ff_result: Optional[Callable] = None,
+    ff_via: Callable | None = None,
+    ff_result: Callable | None = None,
 ) -> list[Vertex]:
     """
     Perform an iterative depth-first traversal of the given universe, starting
@@ -281,7 +280,7 @@ def dft_iterative(
 
 def dfs_iterative(
     uni: Universe, start: Vertex, attrib: str, val: object
-) -> Optional[Vertex]:
+) -> Vertex | None:
     """
     Perform a non-recursive depth-first search in the given universe.
 

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -7,7 +7,7 @@ Helper functions for graph traversals.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 from edgegraph.structure import (
     Vertex,
@@ -72,7 +72,7 @@ def neighbors(
     vert: Vertex,
     direction_sensitive: int = DIR_SENS_FORWARD,
     unknown_handling: int = LNK_UNKNOWN_ERROR,
-    filterfunc: Optional[Callable] = None,
+    filterfunc: Callable | None = None,
 ) -> list[Vertex]:
     """
     Identify the neighbors of a given vertex.
@@ -294,7 +294,7 @@ def find_links(
     v2: Vertex,
     direction_sensitive: bool = True,
     unknown_handling: int = LNK_UNKNOWN_ERROR,
-    filterfunc: Optional[Callable] = None,
+    filterfunc: Callable | None = None,
 ) -> set[Link]:
     """
     Find the link(s) that connect v1 to v2.


### PR DESCRIPTION
Apparently, `Optional[x]` is deprecated: https://mypy.readthedocs.io/en/stable/kinds_of_types.html#optional-types-and-the-none-type

This PR removes `Optional[x]` and replaces it with `x | None`.