### PR TITLE
v0.9.1: fix breadthfirst traversal returning None instead of []

### DIFF
--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -222,7 +222,7 @@ def bft(
     unknown_handling: int = helpers.LNK_UNKNOWN_ERROR,
     ff_via: Callable | None = None,
     ff_result: Callable | None = None,
-) -> list[Vertex] | None:
+) -> list[Vertex]:
     """
     Perform a breadth-first traversal (**non**-generator).
 
@@ -248,6 +248,4 @@ def bft(
             ff_result=ff_result,
         )
     )
-    if not out:
-        return None
     return out

--- a/edgegraph/version.py
+++ b/edgegraph/version.py
@@ -20,6 +20,6 @@ VERSION_MINOR = 9
 #: patch version number (the Z in vX.Y.Z)
 #:
 #: :type: int
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 __version__ = f"{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}"

--- a/tests/traversal/test_breadthfirst.py
+++ b/tests/traversal/test_breadthfirst.py
@@ -144,7 +144,7 @@ def test_bft_empty():
     Ensure no traversal on an empty universe.
     """
     trav = breadthfirst.bft(Universe(), None)
-    assert trav is None, "BFT did not return None on empty universe!"
+    assert trav == [], "BFT did not return [] on empty universe!"
 
 
 def test_bft_nonuniverse_vert(graph_clrs09_22_6):


### PR DESCRIPTION
This was intentional, but I've decided it was a mistake.

**Category**

This PR is a

* [x] Bugfix
  * [x] Hotfix merging directly into `master`
* [ ] New feature
* [ ] Version release
* [ ] General code quality improvement
* [ ] Something else: (please describe)

**Description**

In v0.9.0, the iterator-wrapped breadth first traversal (`bft()`) returns `None` when there is no data in the traversal.  Though this was intentional, I think it was a bad choice, and one bad enough to warrant a hotfix.

**Related issues**

N/A

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

