### PR TITLE
Replace universe._vertices with a list type

### DIFF
--- a/docs/usage/91-performance.rst
+++ b/docs/usage/91-performance.rst
@@ -47,7 +47,7 @@ time before graph traversals begin.**
    Vertex.NEIGHBOR_CACHING = True
 
    uni = randgraph.randgraph(count=1000)
-   start = list(uni.vertices)[0]
+   start = uni.vertices[0]
 
    for i in range(1000):
 
@@ -115,7 +115,7 @@ classmethod, as shown below:
    Vertex.NEIGHBOR_CACHING = True
 
    uni = randgraph.randgraph(count=1000)
-   start = list(uni.vertices)[0]
+   start = uni.vertices[0]
 
    for i in range(1000):
 

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -88,9 +88,13 @@ class BaseObject(object):
         #: Internal reference to the universes this object is a part of
         #:
         #: :meta private:
-        self._universes = universes or set()
-        if not isinstance(self._universes, set):
-            self._universes = set(self._universes)
+        self._universes = universes or []
+        if not isinstance(self._universes, list):
+            self._universes = list(self._universes)
+
+        # deduplicate it while keeping order
+        # https://stackoverflow.com/a/17016257
+        self._universes = [*dict.fromkeys(self._universes)]
 
     @property
     def uid(self) -> int:
@@ -100,7 +104,7 @@ class BaseObject(object):
         return self._uid
 
     @property
-    def universes(self) -> frozenset[Universe]:
+    def universes(self) -> list[Universe]:
         """
         Get the universes this object belongs to.
 
@@ -113,7 +117,7 @@ class BaseObject(object):
            :py:meth:`~edgegraph.structure.base.BaseObject.remove_from_universe`
            to add or remove this object from a given universe
         """
-        return frozenset(self._universes)
+        return list(self._universes)
 
     def add_to_universe(self, universe: Universe) -> None:
         """
@@ -122,14 +126,18 @@ class BaseObject(object):
 
         :param universe: the new universe to add this object to
         """
-        self._universes.add(universe)
+        # do not accept duplicates
+        if universe in self._universes:
+            return
+
+        self._universes.append(universe)
 
     def remove_from_universe(self, universe: Universe) -> None:
         """
         Remove this object from the specified universe.
 
         :param universe: the universe that this object will be removed from
-        :raises KeyError: if this object is not present in the given universe
+        :raises ValueError: if this object is not present in the given universe
         """
         self._universes.remove(universe)
 

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -108,8 +108,8 @@ class BaseObject(object):
         """
         Get the universes this object belongs to.
 
-        Note that this gives you a :py:class:`frozenset`; you cannot add or
-        remove universes from this attribute.
+        Note that the copy returned is just that, a copy.  Modifications to
+        this list that you may make will have no effect on the object.
 
         .. seealso::
 

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -222,6 +222,11 @@ class Universe(vertex.Vertex):
         Note that the returned copy is just that, a copy.  Modifications to the
         list that you may make will have no impact to the universe.
 
+        .. seealso::
+
+           :py:meth:`add_vertex` can be used to add a vertex, and
+           :py:meth:`remove_vertex` can be used to remove one.
+
         :return: vertices belonging to this universe, ordered by insertion
            order.
         """
@@ -234,6 +239,11 @@ class Universe(vertex.Vertex):
         The vertex in question will automatically have its universes updated to
         include this one, if needed.  If the vertex is already present, no
         action is taken.
+
+        .. seealso::
+
+           :py:attr:`vertices` to see what vertices are present in this
+           universe, and :py:meth:`remove_vertex` to remove a vertex.
 
         :param vert: the vertex to be added
         """

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -215,11 +215,15 @@ class Universe(vertex.Vertex):
                 self.add_vertex(v)
 
     @property
-    def vertices(self):
+    def vertices(self) -> list[vertex.Vertex]:
         """
-        Return a (frozen) set of the vertices in this universe.
+        Return a list of vertices that this universe contains.
 
-        :rtype: list[Vertex]
+        Note that the returned copy is just that, a copy.  Modifications to the
+        list that you may make will have no impact to the universe.
+
+        :return: vertices belonging to this universe, ordered by insertion
+           order.
         """
         return list(self._vertices)
 

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -209,7 +209,7 @@ class Universe(vertex.Vertex):
         self._laws.applies_to = self
 
         #: Internal set of vertices
-        self._vertices: set[Vertex] = set()
+        self._vertices: list[Vertex] = []
         if vertices is not None:
             for v in vertices:
                 self.add_vertex(v)
@@ -219,20 +219,24 @@ class Universe(vertex.Vertex):
         """
         Return a (frozen) set of the vertices in this universe.
 
-        :rtype: frozenset[Vertex]
+        :rtype: list[Vertex]
         """
-        return frozenset(self._vertices)
+        return list(self._vertices)
 
     def add_vertex(self, vert: vertex.Vertex):
         """
         Adds a new vertex to this universe.
 
         The vertex in question will automatically have its universes updated to
-        include this one, if needed.
+        include this one, if needed.  If the vertex is already present, no
+        action is taken.
 
         :param vert: the vertex to be added
         """
-        self._vertices.add(vert)
+        if vert in self._vertices:
+            return
+
+        self._vertices.append(vert)
         if self not in vert.universes:
             vert.add_to_universe(self)
 

--- a/tests/structure/test_base.py
+++ b/tests/structure/test_base.py
@@ -206,8 +206,9 @@ def test_base_obj_universes():
     assert uni not in bo._universes, "remove_from_universe didn't!"
 
     # should fail, as the universe has already been removed.  when trying to
-    # remove an object from a set that does not contain it, you get a KeyError
-    with pytest.raises(KeyError):
+    # remove an object from a list that does not contain it, you get a
+    # ValueError
+    with pytest.raises(ValueError):
         bo.remove_from_universe(uni)
 
 
@@ -227,7 +228,7 @@ def test_base_obj_init_universes_list():
     assert len(bo.universes) == len(
         unis
     ), "universes passed to __init__ is not same len as .universes!"
-    assert isinstance(bo.universes, frozenset), ".universes gave wrong type"
+    assert isinstance(bo.universes, list), ".universes gave wrong type"
 
 
 def test_base_obj_init_universes_set():
@@ -246,7 +247,7 @@ def test_base_obj_init_universes_set():
     assert len(bo.universes) == len(
         unis
     ), "universes passed to __init__ is not same len as .universes!"
-    assert isinstance(bo.universes, frozenset), ".universes gave wrong type"
+    assert isinstance(bo.universes, list), ".universes gave wrong type"
 
 
 def test_base_obj_init_universes_tuple():
@@ -263,7 +264,7 @@ def test_base_obj_init_universes_tuple():
     assert len(bo.universes) == len(
         unis
     ), "universes passed to __init__ is not same len as .universes!"
-    assert isinstance(bo.universes, frozenset), ".universes gave wrong type"
+    assert isinstance(bo.universes, list), ".universes gave wrong type"
 
 
 def test_base_obj_init_universes_generator():
@@ -285,7 +286,7 @@ def test_base_obj_init_universes_generator():
     assert len(bo.universes) == len(
         unis
     ), "universes passed to __init__ is not same len as .universes!"
-    assert isinstance(bo.universes, frozenset), ".universes gave wrong type"
+    assert isinstance(bo.universes, list), ".universes gave wrong type"
 
 
 def test_base_obj_init_universes_deduplicate():

--- a/tests/structure/test_universe.py
+++ b/tests/structure/test_universe.py
@@ -39,7 +39,7 @@ def test_universe_vertex_add():
     u.add_vertex(vs[0])
 
     assert isinstance(
-        u.vertices, frozenset
+        u.vertices, list
     ), f"universe.vertices gave wrong type {type(u.vertices)}"
 
     assert (
@@ -54,6 +54,13 @@ def test_universe_vertex_add():
     assert (
         u in vs[1].universes
     ), "universes.add_vertex did not set u in vertex.universes"
+
+    # try adding one the wrong way to make sure it doesn't work
+    u.vertices.append(vs[2])
+    assert vs[2] not in u.vertices, "should not be able to add vertex directly"
+    assert (
+        u not in vs[2].universes
+    ), "backwards effects of adding vertices improperly"
 
 
 def test_universe_vertex_remove():
@@ -90,9 +97,7 @@ def test_universe_vertex_init():
 
     u = universe.Universe(vertices=vs)
 
-    assert isinstance(
-        u.vertices, frozenset
-    ), "universe.vertices gave wrong type"
+    assert isinstance(u.vertices, list), "universe.vertices gave wrong type"
     assert (
         len(u.vertices) == 100
     ), "wrong number of objects in universe.vertices (from __init__)"

--- a/tests/structure/test_vertex.py
+++ b/tests/structure/test_vertex.py
@@ -162,14 +162,14 @@ def test_vert_init_with_uni():
 
     v1 = vertex.Vertex(universes=[unis[0]])
 
-    assert v1.universes == set(
-        [unis[0]]
-    ), "vertex .universes does not match what was given to init!"
+    assert v1.universes == [
+        unis[0]
+    ], "vertex .universes does not match what was given to init!"
     assert v1 in unis[0].vertices, "vertex did not register itself in universe!"
 
     v2 = vertex.Vertex(universes=unis)
-    assert v2.universes == set(
-        unis
+    assert (
+        v2.universes == unis
     ), "vertex .universes does not match what was given to init!"
     for uni in unis:
         assert (


### PR DESCRIPTION
**Category**

This PR is a

* [ ] Bugfix
  * [ ] Hotfix merging directly into `master`
* [x] New feature
* [ ] Version release
* [x] General code quality improvement
* [ ] Something else: (please describe)

**Description**

Replaces the storage type of `Universe._vertices` with a list rather than a set, thus preserving vertex insertion order in a universe.  The primary interest for this is to increase reproducability across runs of the same code, especially when being pickled/unpickled.

**Related issues**

Fixes #91.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

