### PR TITLE
Add generator version of `neighbors()`

### DIFF
--- a/edgegraph/output/plaintext.py
+++ b/edgegraph/output/plaintext.py
@@ -93,9 +93,9 @@ def basic_render(
         line += f"{start} -> "
 
         if sort:
-            nbs = sorted(helpers.neighbors(vert), key=sort)
+            nbs = sorted(helpers.ineighbors(vert), key=sort)
         else:
-            nbs = helpers.neighbors(vert)
+            nbs = helpers.ineighbors(vert)
         for end in nbs:
             if rfunc:
                 node = rfunc(end)

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -199,6 +199,24 @@ class Vertex(base.BaseObject):
         self._CACHE_STATS[self.uid][3] += 1
         self.__qa_nb_cache[args] = answer
 
+    def _qa_neighbors_insert_1(self, item, *args):
+        """
+        Insert one item into the quick-access neighbors cache.
+
+        **FOR INTERNAL USE ONLY!!**
+
+        This function inserts the given item into the "answer key" for this
+        object, with a key of ``*args``.
+
+        :param item: The item to insert.
+        :param *args: Arguments passed to the neighbors() function.
+        """
+        if not self.NEIGHBOR_CACHING:
+            return
+        if args not in self.__qa_nb_cache:
+            self.__qa_nb_cache[args] = []
+        self.__qa_nb_cache[args].append(item)
+
     def add_to_link(self, link: Link):
         """
         Add this vertex to a link.

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -56,21 +56,19 @@ class Vertex(base.BaseObject):
 
         if cls.NEIGHBOR_CACHING:
 
-            totals = [0, 0, 0, 0, 0]
+            totals = [0, 0, 0, 0]
             for _, stat in cls._CACHE_STATS.items():
                 totals[0] += stat[0]
                 totals[1] += stat[1]
                 totals[2] += stat[2]
                 totals[3] += stat[3]
-                totals[4] += stat[4]
 
             lines.append("=== CACHE STATISTICS OVERALL ===")
             lines.append(f"Size:          {len(Vertex._CACHE_STATS)}")
             lines.append(f"Hits:          {totals[0]}")
             lines.append(f"Misses:        {totals[1]}")
             lines.append(f"Invalidations: {totals[2]}")
-            lines.append(f"Insertions:    {totals[3]}")
-            lines.append(f"1-item insrts: {totals[4]}")
+            lines.append(f"1-item insrts: {totals[3]}")
 
         else:
             lines.append("Neighbor caching is DISABLED")
@@ -184,23 +182,6 @@ class Vertex(base.BaseObject):
         self._CACHE_STATS[self.uid][2] += 1
         self.__qa_nb_cache = {}
 
-    def _qa_neighbors_insert(self, answer, *args):
-        """
-        Insert data into the quick-access neighbor cache.
-
-        **FOR INTERNAL USE ONLY!!**
-
-        This function inserts the "answer" into the neighbor cache for this
-        object, with a key of ``*args``.
-
-        :param answer: the neighbors of this object
-        :param *args: Arguments passed to the neighbors() function
-        """
-        if not self.NEIGHBOR_CACHING:
-            return
-        self._CACHE_STATS[self.uid][3] += 1
-        self.__qa_nb_cache[args] = answer
-
     def _qa_neighbors_insert_1(self, item, *args):
         """
         Insert one item into the quick-access neighbors cache.
@@ -218,7 +199,7 @@ class Vertex(base.BaseObject):
         if args not in self.__qa_nb_cache:
             self.__qa_nb_cache[args] = []
 
-        self._CACHE_STATS[self.uid][4] += 1
+        self._CACHE_STATS[self.uid][3] += 1
         self.__qa_nb_cache[args].append(item)
 
     def add_to_link(self, link: Link):

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -56,12 +56,13 @@ class Vertex(base.BaseObject):
 
         if cls.NEIGHBOR_CACHING:
 
-            totals = [0, 0, 0, 0]
+            totals = [0, 0, 0, 0, 0]
             for _, stat in cls._CACHE_STATS.items():
                 totals[0] += stat[0]
                 totals[1] += stat[1]
                 totals[2] += stat[2]
                 totals[3] += stat[3]
+                totals[4] += stat[4]
 
             lines.append("=== CACHE STATISTICS OVERALL ===")
             lines.append(f"Size:          {len(Vertex._CACHE_STATS)}")
@@ -69,6 +70,7 @@ class Vertex(base.BaseObject):
             lines.append(f"Misses:        {totals[1]}")
             lines.append(f"Invalidations: {totals[2]}")
             lines.append(f"Insertions:    {totals[3]}")
+            lines.append(f"1-item insrts: {totals[4]}")
 
         else:
             lines.append("Neighbor caching is DISABLED")
@@ -98,7 +100,7 @@ class Vertex(base.BaseObject):
         """
         super().__init__(uid=uid, attributes=attributes, universes=universes)
 
-        self._CACHE_STATS.update({self.uid: [0, 0, 0, 0]})
+        self._CACHE_STATS.update({self.uid: [0, 0, 0, 0, 0]})
 
         #: Links that this vertex is associated with
         #:
@@ -215,6 +217,8 @@ class Vertex(base.BaseObject):
             return
         if args not in self.__qa_nb_cache:
             self.__qa_nb_cache[args] = []
+
+        self._CACHE_STATS[self.uid][4] += 1
         self.__qa_nb_cache[args].append(item)
 
     def add_to_link(self, link: Link):

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -68,7 +68,7 @@ class Vertex(base.BaseObject):
             lines.append(f"Hits:          {totals[0]}")
             lines.append(f"Misses:        {totals[1]}")
             lines.append(f"Invalidations: {totals[2]}")
-            lines.append(f"1-item insrts: {totals[3]}")
+            lines.append(f"Insertions:    {totals[3]}")
 
         else:
             lines.append("Neighbor caching is DISABLED")
@@ -98,7 +98,7 @@ class Vertex(base.BaseObject):
         """
         super().__init__(uid=uid, attributes=attributes, universes=universes)
 
-        self._CACHE_STATS.update({self.uid: [0, 0, 0, 0, 0]})
+        self._CACHE_STATS.update({self.uid: [0, 0, 0, 0]})
 
         #: Links that this vertex is associated with
         #:
@@ -182,25 +182,22 @@ class Vertex(base.BaseObject):
         self._CACHE_STATS[self.uid][2] += 1
         self.__qa_nb_cache = {}
 
-    def _qa_neighbors_insert_1(self, item, *args):
+    def _qa_neighbors_insert(self, answer, *args):
         """
-        Insert one item into the quick-access neighbors cache.
+        Insert data into the quick-access neighbor cache.
 
         **FOR INTERNAL USE ONLY!!**
 
-        This function inserts the given item into the "answer key" for this
+        This function inserts the "answer" into the neighbor cache for this
         object, with a key of ``*args``.
 
-        :param item: The item to insert.
-        :param *args: Arguments passed to the neighbors() function.
+        :param answer: the neighbors of this object
+        :param *args: Arguments passed to the neighbors() function
         """
         if not self.NEIGHBOR_CACHING:
             return
-        if args not in self.__qa_nb_cache:
-            self.__qa_nb_cache[args] = []
-
         self._CACHE_STATS[self.uid][3] += 1
-        self.__qa_nb_cache[args].append(item)
+        self.__qa_nb_cache[args] = answer
 
     def add_to_link(self, link: Link):
         """

--- a/edgegraph/traversal/breadthfirst.py
+++ b/edgegraph/traversal/breadthfirst.py
@@ -90,7 +90,7 @@ def bfs(
 
     while queue:
         u = queue.popleft()
-        for v in helpers.neighbors(u):
+        for v in helpers.ineighbors(u):
 
             if (uni is not None) and (v not in uni.vertices):
                 continue
@@ -195,7 +195,7 @@ def ibft(
 
     while queue:
         u = queue.popleft()
-        for v in helpers.neighbors(
+        for v in helpers.ineighbors(
             u,
             direction_sensitive=direction_sensitive,
             unknown_handling=unknown_handling,

--- a/edgegraph/traversal/depthfirst.py
+++ b/edgegraph/traversal/depthfirst.py
@@ -98,7 +98,7 @@ def _dft_recur(
     if (ff_result and ff_result(v)) or (not ff_result):
         yield v
 
-    for w in helpers.neighbors(
+    for w in helpers.ineighbors(
         v,
         direction_sensitive=direction_sensitive,
         unknown_handling=unknown_handling,
@@ -218,7 +218,7 @@ def _dfs_recur(
     :return: The target vertex, or None if not found in this subtree.
     """
     visited[v] = None
-    for w in helpers.neighbors(v):
+    for w in helpers.ineighbors(v):
         if (uni is not None) and (w not in uni.vertices):
             continue
         if w not in visited:
@@ -311,7 +311,7 @@ def idft_iterative(
             if (ff_result and ff_result(v)) or (not ff_result):
                 yield v
 
-            for w in helpers.neighbors(
+            for w in helpers.ineighbors(
                 v,
                 direction_sensitive=direction_sensitive,
                 unknown_handling=unknown_handling,
@@ -397,6 +397,6 @@ def dfs_iterative(
                 if v[attrib] == val:
                     return v
             discovered.append(v)
-            for w in helpers.neighbors(v):
+            for w in helpers.ineighbors(v):
                 stack.append(w)
     return None

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -186,6 +186,8 @@ def ineighbors(
         yield from cached
         return
 
+    cache = []
+
     for link in vert.links:
 
         v2 = link.other(vert)
@@ -204,11 +206,8 @@ def ineighbors(
                 # this goes for all three places filterfunc() is used in this
                 # neighbors function
                 if filterfunc is None or filterfunc(link, v2):
-                    # see note near top of this function for justification
-                    # pylint: disable-next=protected-access
-                    vert._qa_neighbors_insert_1(
-                        v2, direction_sensitive, unknown_handling, filterfunc
-                    )
+                    if Vertex.NEIGHBOR_CACHING:
+                        cache.append(v2)
                     yield v2
                 else:
 
@@ -228,11 +227,8 @@ def ineighbors(
                 # see above notes on short-circuiting filterfunc() if it's not
                 # provided
                 if filterfunc is None or filterfunc(link, v2):
-                    # see note near top of this function for justification
-                    # pylint: disable-next=protected-access
-                    vert._qa_neighbors_insert_1(
-                        v2, direction_sensitive, unknown_handling, filterfunc
-                    )
+                    if Vertex.NEIGHBOR_CACHING:
+                        cache.append(v2)
                     yield v2
                 else:
                     # see comment on the above else: continue block for
@@ -240,8 +236,6 @@ def ineighbors(
                     continue  # pragma: no cover
 
             # we're looking at v2 -- the destination
-            # TODO: is it more time efficient to move the v1/v2 comparison into
-            # an if nested under the directededge check?
             elif issubclass(type(link), DirectedEdge) and (link.v2 is vert):
                 pass
 
@@ -252,11 +246,8 @@ def ineighbors(
                 if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
                     yld = link.other(vert)
 
-                    # see note near top of this function for justification
-                    # pylint: disable-next=protected-access
-                    vert._qa_neighbors_insert_1(
-                        yld, direction_sensitive, unknown_handling, filterfunc
-                    )
+                    if Vertex.NEIGHBOR_CACHING:
+                        cache.append(yld)
                     yield yld
                 else:
                     raise NotImplementedError(
@@ -268,11 +259,8 @@ def ineighbors(
             if issubclass(type(link), UnDirectedEdge):
 
                 if filterfunc is None or filterfunc(link, v2):
-                    # see note near top of this function for justification
-                    # pylint: disable-next=protected-access
-                    vert._qa_neighbors_insert_1(
-                        v2, direction_sensitive, unknown_handling, filterfunc
-                    )
+                    if Vertex.NEIGHBOR_CACHING:
+                        cache.append(v2)
                     yield v2
                 else:
                     # see comment on the above else: continue block for
@@ -285,11 +273,8 @@ def ineighbors(
                 # see above notes on short-circuiting filterfunc() if it's not
                 # provided
                 if filterfunc is None or filterfunc(link, v2):
-                    # see note near top of this function for justification
-                    # pylint: disable-next=protected-access
-                    vert._qa_neighbors_insert_1(
-                        v2, direction_sensitive, unknown_handling, filterfunc
-                    )
+                    if Vertex.NEIGHBOR_CACHING:
+                        cache.append(v2)
                     yield v2
                 else:
                     # see comment on the above else: continue block for
@@ -297,8 +282,6 @@ def ineighbors(
                     continue  # pragma: no cover
 
             # we're looking at v2 -- the destination
-            # TODO: is it more time efficient to move the v1/v2 comparison into
-            # an if nested under the directededge check?
             elif issubclass(type(link), DirectedEdge) and (link.v1 is vert):
                 pass
 
@@ -309,11 +292,8 @@ def ineighbors(
                 if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
                     yld = link.other(vert)
 
-                    # see note near top of this function for justification
-                    # pylint: disable-next=protected-access
-                    vert._qa_neighbors_insert_1(
-                        yld, direction_sensitive, unknown_handling, filterfunc
-                    )
+                    if Vertex.NEIGHBOR_CACHING:
+                        cache.append(yld)
                     yield yld
                 else:
                     raise NotImplementedError(
@@ -324,11 +304,8 @@ def ineighbors(
             # see above notes on short-circuiting filterfunc() if it's not
             # provided
             if filterfunc is None or filterfunc(link, v2):
-                # see note near top of this function for justification
-                # pylint: disable-next=protected-access
-                vert._qa_neighbors_insert_1(
-                    v2, direction_sensitive, unknown_handling, filterfunc
-                )
+                if Vertex.NEIGHBOR_CACHING:
+                    cache.append(v2)
                 yield v2
 
         else:
@@ -336,6 +313,8 @@ def ineighbors(
                 f"Unknown option for direction_sensitive = {direction_sensitive}"
             )
 
+    if Vertex.NEIGHBOR_CACHING:
+        vert._qa_neighbors_insert(cache, direction_sensitive, unknown_handling, filterfunc)
 
 def neighbors(
     vert: Vertex,

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -313,7 +313,10 @@ def ineighbors(
                 f"Unknown option for direction_sensitive = {direction_sensitive}"
             )
 
-    vert._qa_neighbors_insert(cache, direction_sensitive, unknown_handling, filterfunc)
+    vert._qa_neighbors_insert(
+        cache, direction_sensitive, unknown_handling, filterfunc
+    )
+
 
 def neighbors(
     vert: Vertex,

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -313,8 +313,7 @@ def ineighbors(
                 f"Unknown option for direction_sensitive = {direction_sensitive}"
             )
 
-    if Vertex.NEIGHBOR_CACHING:
-        vert._qa_neighbors_insert(cache, direction_sensitive, unknown_handling, filterfunc)
+    vert._qa_neighbors_insert(cache, direction_sensitive, unknown_handling, filterfunc)
 
 def neighbors(
     vert: Vertex,

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -203,7 +203,11 @@ def ineighbors(
                 # this goes for all three places filterfunc() is used in this
                 # neighbors function
                 if filterfunc is None or filterfunc(link, v2):
-                    vert._qa_neighbors_insert_1(v2, direction_sensitive, unknown_handling, filterfunc)
+                    # see note near top of this function for justification
+                    # pylint: disable-next=protected-access
+                    vert._qa_neighbors_insert_1(
+                        v2, direction_sensitive, unknown_handling, filterfunc
+                    )
                     yield v2
                 else:
 
@@ -223,7 +227,11 @@ def ineighbors(
                 # see above notes on short-circuiting filterfunc() if it's not
                 # provided
                 if filterfunc is None or filterfunc(link, v2):
-                    vert._qa_neighbors_insert_1(v2, direction_sensitive, unknown_handling, filterfunc)
+                    # see note near top of this function for justification
+                    # pylint: disable-next=protected-access
+                    vert._qa_neighbors_insert_1(
+                        v2, direction_sensitive, unknown_handling, filterfunc
+                    )
                     yield v2
                 else:
                     # see comment on the above else: continue block for
@@ -242,7 +250,12 @@ def ineighbors(
 
                 if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
                     yld = link.other(vert)
-                    vert._qa_neighbors_insert_1(yld, direction_sensitive, unknown_handling, filterfunc)
+
+                    # see note near top of this function for justification
+                    # pylint: disable-next=protected-access
+                    vert._qa_neighbors_insert_1(
+                        yld, direction_sensitive, unknown_handling, filterfunc
+                    )
                     yield yld
                 else:
                     raise NotImplementedError(
@@ -254,7 +267,11 @@ def ineighbors(
             if issubclass(type(link), UnDirectedEdge):
 
                 if filterfunc is None or filterfunc(link, v2):
-                    vert._qa_neighbors_insert_1(v2, direction_sensitive, unknown_handling, filterfunc)
+                    # see note near top of this function for justification
+                    # pylint: disable-next=protected-access
+                    vert._qa_neighbors_insert_1(
+                        v2, direction_sensitive, unknown_handling, filterfunc
+                    )
                     yield v2
                 else:
                     # see comment on the above else: continue block for
@@ -267,7 +284,11 @@ def ineighbors(
                 # see above notes on short-circuiting filterfunc() if it's not
                 # provided
                 if filterfunc is None or filterfunc(link, v2):
-                    vert._qa_neighbors_insert_1(v2, direction_sensitive, unknown_handling, filterfunc)
+                    # see note near top of this function for justification
+                    # pylint: disable-next=protected-access
+                    vert._qa_neighbors_insert_1(
+                        v2, direction_sensitive, unknown_handling, filterfunc
+                    )
                     yield v2
                 else:
                     # see comment on the above else: continue block for
@@ -286,7 +307,12 @@ def ineighbors(
 
                 if unknown_handling == LNK_UNKNOWN_NEIGHBOR:
                     yld = link.other(vert)
-                    vert._qa_neighbors_insert_1(yld, direction_sensitive, unknown_handling, filterfunc)
+
+                    # see note near top of this function for justification
+                    # pylint: disable-next=protected-access
+                    vert._qa_neighbors_insert_1(
+                        yld, direction_sensitive, unknown_handling, filterfunc
+                    )
                     yield yld
                 else:
                     raise NotImplementedError(
@@ -297,7 +323,11 @@ def ineighbors(
             # see above notes on short-circuiting filterfunc() if it's not
             # provided
             if filterfunc is None or filterfunc(link, v2):
-                vert._qa_neighbors_insert_1(v2, direction_sensitive, unknown_handling, filterfunc)
+                # see note near top of this function for justification
+                # pylint: disable-next=protected-access
+                vert._qa_neighbors_insert_1(
+                    v2, direction_sensitive, unknown_handling, filterfunc
+                )
                 yield v2
 
         else:
@@ -305,13 +335,17 @@ def ineighbors(
                 f"Unknown option for direction_sensitive = {direction_sensitive}"
             )
 
+
 def neighbors(
     vert: Vertex,
     direction_sensitive: int = DIR_SENS_FORWARD,
     unknown_handling: int = LNK_UNKNOWN_ERROR,
     filterfunc: Callable | None = None,
 ) -> list[Vertex]:
-    return list(ineighbors(vert, direction_sensitive, unknown_handling, filterfunc))
+    return list(
+        ineighbors(vert, direction_sensitive, unknown_handling, filterfunc)
+    )
+
 
 def find_links(
     v1: Vertex,

--- a/edgegraph/traversal/helpers.py
+++ b/edgegraph/traversal/helpers.py
@@ -74,7 +74,7 @@ def ineighbors(
     filterfunc: Callable | None = None,
 ) -> list[Vertex]:
     """
-    Identify the neighbors of a given vertex.
+    Identify the neighbors of a given vertex (generator).
 
     This function checks the edges associated with the given vertex, identifies
     the vertices on the other end of those edges, and returns them.  It
@@ -100,13 +100,13 @@ def ineighbors(
 
     the function would operate as:
 
-    >>> neighbors(v1)
+    >>> list(ineighbors(v1))
     [v2, v3]
-    >>> neighbors(v1, direction_sensitive=DIR_SENS_FORWARD)
+    >>> list(ineighbors(v1, direction_sensitive=DIR_SENS_FORWARD))
     [v2, v3, v4]
-    >>> neighbors(v4)
+    >>> list(ineighbors(v4))
     [v1]
-    >>> neighbors(v4, direction_sensitive=DIR_SENS_ANY)
+    >>> list(ineighbors(v4, direction_sensitive=DIR_SENS_ANY))
     [v1, v3]
 
     If supplied, the ``filterfunc`` argument should be to a callable object
@@ -130,9 +130,9 @@ def ineighbors(
     For example, one may wish to only consider vertices if a given attribute
     meets some criteria:
 
-    >>> neighbors(v1)
+    >>> list(ineighbors(v1))
     [v2, v3]
-    >>> neighbors(v1, filterfunc=lambda e, v2: v2.i >= 3)
+    >>> list(ineighbors(v1, filterfunc=lambda e, v2: v2.i >= 3))
     [v3]
 
     .. note::
@@ -168,8 +168,9 @@ def ineighbors(
        vertex should be included in the neighbors output.
     :raises NotImplementedError: if kwarg ``unknown_handling`` is set to
        :py:const:`LNK_UNKNOWN_ERROR` and an unknown edge class is enountered.
-    :return: A list of :py:class:`~edgegraph.structure.vertex.Vertex` objects
-       representing neighbors of the specified vertex.
+    :return: A generator object which yields
+       :py:class:`~edgegraph.structure.vertex.Vertex` objects representing
+       neighbors of the specified vertex.
     """
 
     # pylint complains about this operation, with fairly good reason -- we're
@@ -342,6 +343,26 @@ def neighbors(
     unknown_handling: int = LNK_UNKNOWN_ERROR,
     filterfunc: Callable | None = None,
 ) -> list[Vertex]:
+    """
+    Identify the neighbors of a given vertex (**non**-generator).
+
+    This function checks the edges associated with the given vertex, identifies
+    the vertices on the other end of those edges, and returns them.  It
+    respects edge directionality if/when necessary, and can handle arbitrary
+    edge types given they are subclasses of either
+    :py:class:`~edgegraph.structure.directededge.DirectedEdge` or
+    :py:class:`~edgegraph.structure.undirectededge.UnDirectedEdge`.
+
+    .. seealso::
+
+       Please refer to the documentation of :py:func:`ineighbors`!  This
+       function simply wraps that one, only forcing full expansion to a list
+       before returning.  All parameters are exactly the same and passed
+       through without alteration.
+
+    :return: A list of  :py:class:`~edgegraph.structure.vertex.Vertex` objects
+       representing neighbors of the specified vertex.
+    """
     return list(
         ineighbors(vert, direction_sensitive, unknown_handling, filterfunc)
     )

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -18,7 +18,7 @@ python3 -m pytest \
     -o log_cli=true \
     -vv
 
-mv prof/combined.svg docs/_build/
+mv prof/combined.svg docs/_build/combined-$(date -Iseconds).svg
 
 echo Done!
 

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -66,6 +66,52 @@ def test_neighbors_directed():
     assert v0nb == [v[1]], "v0 neighbors incorrect!"
     assert v1nb == [v[2]], "v1 neighbors incorrect!"
 
+def test_ineighbors_generator():
+    """
+    Ensure the ineighbors function yields an iterator.
+    """
+    v = [Vertex(), Vertex(), Vertex(), Vertex()]
+    adj = {
+        v[0]: [v[1]],
+        v[1]: [v[2]],
+    }
+    adjlist.load_adj_dict(adj, UnDirectedEdge)
+
+    v0nb = helpers.ineighbors(v[0])
+
+    assert hasattr(v0nb, '__next__'), "ineighbors() did not return a generator!"
+    assert hasattr(v0nb, 'send'), "ineighbors() did not return a generator!"
+
+    exp = list(v0nb)
+
+    assert exp == [v[1]], "ineighbors yielded wrong values!"
+
+
+def test_ineighbors_partial_cache_safety():
+    """
+    Ensure the ineighbors function isn't buggy with partial cache insertions.
+    """
+    v = [Vertex(), Vertex(), Vertex(), Vertex()]
+    adj = {
+        v[0]: [v[1], v[2], v[3]],
+    }
+    nb = helpers.neighbors(v[0])
+    assert nb == [], "neighbors before linking!"
+
+    adjlist.load_adj_dict(adj, UnDirectedEdge)
+
+    itr = helpers.ineighbors(v[0])
+
+    assert next(itr) == v[1], "First of ineighbors() wrong!"
+    assert next(itr) == v[2], "Second of ineighbors() wrong!"
+
+    # DON'T call next again to get the third neighbor
+
+    itr2 = helpers.ineighbors(v[0])
+    nbs = list(itr2)
+
+    assert nbs == [v[1], v[2], v[3]], "ineighbors left a partial cache!!!"
+
 
 def test_neighbors_directed_nonsensitive():
     """
@@ -567,7 +613,6 @@ def test_findlinks_filterfunc():
     assert l4 == {
         e2,
     }, "find_links did not find the right link!"
-
 
 @pytest.mark.slow
 @pytest.mark.parametrize("n_links", [1, 10, 100, 500])

--- a/tests/traversal/test_helpers.py
+++ b/tests/traversal/test_helpers.py
@@ -66,6 +66,7 @@ def test_neighbors_directed():
     assert v0nb == [v[1]], "v0 neighbors incorrect!"
     assert v1nb == [v[2]], "v1 neighbors incorrect!"
 
+
 def test_ineighbors_generator():
     """
     Ensure the ineighbors function yields an iterator.
@@ -79,8 +80,8 @@ def test_ineighbors_generator():
 
     v0nb = helpers.ineighbors(v[0])
 
-    assert hasattr(v0nb, '__next__'), "ineighbors() did not return a generator!"
-    assert hasattr(v0nb, 'send'), "ineighbors() did not return a generator!"
+    assert hasattr(v0nb, "__next__"), "ineighbors() did not return a generator!"
+    assert hasattr(v0nb, "send"), "ineighbors() did not return a generator!"
 
     exp = list(v0nb)
 
@@ -613,6 +614,7 @@ def test_findlinks_filterfunc():
     assert l4 == {
         e2,
     }, "find_links did not find the right link!"
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize("n_links", [1, 10, 100, 500])


### PR DESCRIPTION
**Category**

This PR is a

* [ ] Bugfix
  * [ ] Hotfix merging directly into `master`
* [x] New feature
* [ ] Version release
* [ ] General code quality improvement
* [ ] Something else: (please describe)

**Description**

Adds the `ineighbors()` function, which is a generator equivalent of `neighbors()`.  The `neighbors()` function still exists, but simply calls `list(ineighbors(...))`.

**Related issues**

Fixes #95.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

