### PR TITLE
Python 3.13t CI testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: MyPy type-hinting check
       # similarly to black, we only need to run this on latest version
-      if: ${{ matrix.python-version == '3.12' }}
+      if: ${{ matrix.python-version == '3.13' }}
       run: |
         # hide it behind || true to mask mypy lacking an --exit-zero esque flag
         mypy edgegraph || true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
     # get everything set up
     - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: Quansight-Labs/setup-python@v5
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
**Category**

This PR is a

* [ ] Bugfix
  * [ ] Hotfix merging directly into `master`
* [ ] New feature
* [ ] Version release
* [x] General code quality improvement
* [ ] Something else: (please describe)

**Description**

Github Actions has released python 3.13 freethreading support in the `actions/setup-python`:

https://github.com/actions/setup-python/issues/771

Also see HugoVK's guide to using it: https://hugovk.dev/blog/2025/free-threaded-python-on-github-actions/ .

[EDIT] While examining CI logs in this PR, noticed that MyPy type checking was running on py3.12, not 3.13.  Snuck in a fix for this too.

**Related issues**

Finally closes #48.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

