### PR TITLE
Bugfix/thread safety

### DIFF
--- a/docs/usage/20-threadsafety.rst
+++ b/docs/usage/20-threadsafety.rst
@@ -1,0 +1,88 @@
+.. _dev/threadsafety:
+
+Thread Safety
+=============
+
+Edgegraph's internal structure is thread-safe; meaning it can be used (read and
+written) from multiple threads within the same process simulatenously without
+the following categories of issues:
+
+#. Data race conditions, in which thread A may read partial data from object
+   state that thread B is currently writing to; and
+#. Deadlock, in which two threads may wait infinitely for the same resource,
+   guarding it from each other
+
+This statement applies to the internal graph structure of the
+:py:class:`~edgegraph.structure.vertex.Vertex` and
+:py:class:`~edgegraph.structure.link.Link` objects, and therefore is inherited
+by all subclasses of them which properly call their superclass methods for
+graph operations (establishing and removing links between vertices).
+
+**However:**
+
+This thread safety is implemented with a series of locks that guard critical
+object state relating to the "joints" of vertices and links.  It does **NOT**
+extend automatically to all user-created instance variables in a subclass of
+any of Edgegraph's classes.
+
+**You as the user of edgegraph are responsible for the thread-safety of your
+own instance variables!**
+
+The developer of edgegraph cannot know what you intend to do with the module,
+and therefore cannot adequately place guardrails for any potential use.  It is
+impossible for me to know how you will use the subclasses of Vertex.
+
+For example, consider the following:
+
+.. code-block:: python
+   :linenos:
+
+   from edgegraph.structure import Vertex
+   from edgegraph.builder import randgraph
+
+   class MyData (Vertex):
+       '''Represents a piece of data.'''
+
+       def __init__(self, data):
+           '''Set up this piece of data.'''
+           super().__init__(self)  # <-- object is thread-safe; no worries here
+
+           self.data = data  # <-- this is NOT thread safe!  guard it!
+
+.. note::
+
+   If you intend to guard custom instance variables within Edgegraph vertices,
+   you may often need to use reentrant locks (RLocks).
+
+   In addition, if you intend to pickle objects containing RLocks, be aware
+   that it doesn't seem to work in conjunction with edgegraph's
+   :py:mod:`non-recursive pickler <edgegraph.output.nrpickler>`.  Internally,
+   edgegraph faces this very problem - and uses ``threading._PyRLock`` to work
+   around it.  It's not a good practice, but seems to be necessary.  See
+   https://github.com/mishaturnbull/edgegraph/issues/118.
+
+Async and Multiprocessing
+-------------------------
+
+Edgegraph does not take measures to guard resources while working with Python's
+async routines or multiprocessing capabilities.  It is up to the user to ensure
+their usage of async / multiprocessing is done in a safe manner.
+
+For the async side, Python's implementation of async leads to a pattern where
+context switches only happen at points explicitly defined by the user.
+Therefore, Edgegraph recommends not switching contexts while a graph update
+operation is happening.
+
+"Multiprocessing safety" is not considered by Edgegraph, as shared memory
+between operating system *processes* requires much more manual setup and
+synchronization by the user compared to threading models.  Further, Python's
+implementation of multiprocessing leads to patterns of data serialization for
+exchange between processes, meaning the same object references are not shared
+directly.  Ergo, the typical threading problems discussed above are not
+relevant.
+
+.. seealso::
+
+   If you do wish to exchange Edgegraph structures between *processes*,
+   consider the custom pickler: :py:mod:`edgegraph.output.nrpickler`.
+

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
+import threading
 
 if TYPE_CHECKING:
     from edgegraph.structure.universe import Universe
@@ -87,6 +88,8 @@ class BaseObject(object):
             for key, val in attributes.items():
                 setattr(self, key, val)
 
+        self._universes_lock = threading._PyRLock()
+
         #: Internal reference to the universes this object is a part of
         #:
         #: :meta private:
@@ -119,7 +122,8 @@ class BaseObject(object):
            :py:meth:`~edgegraph.structure.base.BaseObject.remove_from_universe`
            to add or remove this object from a given universe
         """
-        return list(self._universes)
+        with self._universes_lock:
+            return list(self._universes)
 
     def add_to_universe(self, universe: Universe) -> None:
         """
@@ -129,11 +133,12 @@ class BaseObject(object):
 
         :param universe: the new universe to add this object to
         """
-        # do not accept duplicates
-        if universe in self._universes:
-            return
+        with self._universes_lock:
+            # do not accept duplicates
+            if universe in self._universes:
+                return
 
-        self._universes.append(universe)
+            self._universes.append(universe)
 
     def remove_from_universe(self, universe: Universe) -> None:
         """
@@ -142,7 +147,12 @@ class BaseObject(object):
         :param universe: the universe that this object will be removed from
         :raises ValueError: if this object is not present in the given universe
         """
-        self._universes.remove(universe)
+        with self._universes_lock:
+            try:
+                self._universes.remove(universe)
+            except ValueError:
+                # already was not present; no action required
+                pass
 
     # These three control attrib access via KEYS; bobj['x'], bobj['y'] = y; del
     # bobj['y']  # noqa: ERA001

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -6,10 +6,10 @@ Contains the BaseObject class.
 
 from __future__ import annotations
 
+import threading
 import uuid
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
-import threading
 
 if TYPE_CHECKING:
     from edgegraph.structure.universe import Universe
@@ -148,7 +148,10 @@ class BaseObject(object):
         :raises ValueError: if this object is not present in the given universe
         """
         with self._universes_lock:
-            try:
+            # SIM105 suggests use of contextlib.suppress(ValueError) instead of
+            # this try-except-pass pattern.  however, this does have a slight
+            # performance impact -- which i want to avoid here.
+            try:  # noqa: SIM105
                 self._universes.remove(universe)
             except ValueError:
                 # already was not present; no action required

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -6,8 +6,8 @@ Holds the Link class.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import threading
+from typing import TYPE_CHECKING
 
 from edgegraph.structure import base
 
@@ -76,8 +76,7 @@ class Link(base.BaseObject):
 
         # would love to use regular threading.RLock() here, but it breaks
         # dill...
-        # https://github.com/uqfoundation/dill/issues/321
-        # https://github.com/fal-ai/dbt-fal/pull/850
+        # https://github.com/mishaturnbull/edgegraph/issues/118
         self._verts_link = threading._PyRLock()
 
         #: Vertices that this link links

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -77,13 +77,13 @@ class Link(base.BaseObject):
         # would love to use regular threading.RLock() here, but it breaks
         # dill...
         # https://github.com/mishaturnbull/edgegraph/issues/118
-        self._verts_link = threading._PyRLock()
+        self._verts_lock = threading._PyRLock()
 
         #: Vertices that this link links
         #:
         #: This is a list of vertex objects that are linked together by this
         #: class.
-        with self._verts_link:
+        with self._verts_lock:
             self._vertices: list[Vertex] = []
             if vertices is not None:
                 for vert in vertices:
@@ -98,7 +98,7 @@ class Link(base.BaseObject):
         objects using this attribute is not intended; it is meant to be
         immutable.
         """
-        with self._verts_link:
+        with self._verts_lock:
             return tuple(self._vertices)
 
     def add_vertex(self, new: Vertex):
@@ -107,7 +107,7 @@ class Link(base.BaseObject):
 
         :param new: the vertex to add to the link
         """
-        with self._verts_link:
+        with self._verts_lock:
             self._vertices.append(new)
             if (new is not None) and (self not in new.links):
                 new.add_to_link(self)
@@ -122,7 +122,7 @@ class Link(base.BaseObject):
 
         :param kill: the vertex to unlink
         """
-        with self._verts_link:
+        with self._verts_lock:
             if kill in self._vertices:
                 self._vertices.remove(kill)
 

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -54,6 +54,7 @@ class Link(base.BaseObject):
         :param vertices: list of Vertex objects that this link links
         :param _force_creation: force the instantiation of this object without
            error
+        :concurrency: Thread-safe
 
         .. seealso::
 
@@ -97,6 +98,8 @@ class Link(base.BaseObject):
         A tuple object is given because the addition or removal of vertex
         objects using this attribute is not intended; it is meant to be
         immutable.
+
+        :concurrency: Thread-safe
         """
         with self._verts_lock:
             return tuple(self._vertices)
@@ -106,6 +109,7 @@ class Link(base.BaseObject):
         Add a vertex to this link.
 
         :param new: the vertex to add to the link
+        :concurrency: Thread-safe
         """
         with self._verts_lock:
             self._vertices.append(new)
@@ -121,6 +125,7 @@ class Link(base.BaseObject):
         taken.
 
         :param kill: the vertex to unlink
+        :concurrency: Thread-safe
         """
         with self._verts_lock:
             if kill in self._vertices:

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -74,7 +74,11 @@ class Link(base.BaseObject):
             msg = "Base class <Link> may not be instantiated directly!"
             raise TypeError(msg)
 
-        self._verts_link = threading.RLock()
+        # would love to use regular threading.RLock() here, but it breaks
+        # dill...
+        # https://github.com/uqfoundation/dill/issues/321
+        # https://github.com/fal-ai/dbt-fal/pull/850
+        self._verts_link = threading._PyRLock()
 
         #: Vertices that this link links
         #:

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -7,6 +7,7 @@ Holds the Link class.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import threading
 
 from edgegraph.structure import base
 
@@ -73,14 +74,17 @@ class Link(base.BaseObject):
             msg = "Base class <Link> may not be instantiated directly!"
             raise TypeError(msg)
 
+        self._verts_link = threading.RLock()
+
         #: Vertices that this link links
         #:
         #: This is a list of vertex objects that are linked together by this
         #: class.
-        self._vertices: list[Vertex] = []
-        if vertices is not None:
-            for vert in vertices:
-                self.add_vertex(vert)
+        with self._verts_link:
+            self._vertices: list[Vertex] = []
+            if vertices is not None:
+                for vert in vertices:
+                    self.add_vertex(vert)
 
     @property
     def vertices(self) -> tuple[Vertex, ...]:
@@ -91,7 +95,8 @@ class Link(base.BaseObject):
         objects using this attribute is not intended; it is meant to be
         immutable.
         """
-        return tuple(self._vertices)
+        with self._verts_link:
+            return tuple(self._vertices)
 
     def add_vertex(self, new: Vertex):
         """
@@ -99,9 +104,10 @@ class Link(base.BaseObject):
 
         :param new: the vertex to add to the link
         """
-        self._vertices.append(new)
-        if (new is not None) and (self not in new.links):
-            new.add_to_link(self)
+        with self._verts_link:
+            self._vertices.append(new)
+            if (new is not None) and (self not in new.links):
+                new.add_to_link(self)
 
     def unlink_from(self, kill: Vertex):
         """
@@ -113,8 +119,9 @@ class Link(base.BaseObject):
 
         :param kill: the vertex to unlink
         """
-        if kill in self._vertices:
-            self._vertices.remove(kill)
+        with self._verts_link:
+            if kill in self._vertices:
+                self._vertices.remove(kill)
 
-            if kill is not None:
-                kill.remove_from_link(self)
+                if kill is not None:
+                    kill.remove_from_link(self)

--- a/edgegraph/structure/twoendedlink.py
+++ b/edgegraph/structure/twoendedlink.py
@@ -76,6 +76,7 @@ class TwoEndedLink(link.Link):
         """
         Set one vertex of this edge.
         """
+        # no lock here; it's acquired in _set_v1
         self._set_v1(new)
 
     def _set_v1(self, new: Vertex):
@@ -92,11 +93,13 @@ class TwoEndedLink(link.Link):
         all is well.  Except the access to a private method... but it seems the
         least bad option, IMO.
         """
-        v2 = self.v2
-        self.unlink_from(self.v1)
-        self._vertices = []
-        self.add_vertex(new)
-        self._vertices.append(v2)
+
+        with self._verts_lock:
+            v2 = self.v2
+            self.unlink_from(self.v1)
+            self._vertices = []
+            self.add_vertex(new)
+            self._vertices.append(v2)
 
     @property
     def v2(self) -> Vertex:
@@ -106,13 +109,15 @@ class TwoEndedLink(link.Link):
         Setting this attribute automatically handles link-vertex assocation
         updates; no extra effort is necessary.
         """
-        return self.vertices[1]
+        with self._verts_lock:
+            return self.vertices[1]
 
     @v2.setter
     def v2(self, new: Vertex):
         """
         Set the other end of this edge.
         """
+        # no lock here; it's acquired in _set_v2
         self._set_v2(new)
 
     def _set_v2(self, new: Vertex):
@@ -122,10 +127,11 @@ class TwoEndedLink(link.Link):
         For a brief on why this exists, see
         :py:meth:`~edgegraph.structure.TwoEndedLink._set_v1`.
         """
-        v1 = self.v1
-        self.unlink_from(self.v2)
-        self._vertices = [v1]
-        self.add_vertex(new)
+        with self._verts_lock:
+            v1 = self.v1
+            self.unlink_from(self.v2)
+            self._vertices = [v1]
+            self.add_vertex(new)
 
     def other(self, end: Vertex) -> Vertex | None:
         """
@@ -141,9 +147,11 @@ class TwoEndedLink(link.Link):
         :param end: one end of this edge
         :return: the other end of this edge, or None
         """
-        if end is self.v1:
-            return self.v2
-        if end is self.v2:
-            return self.v1
+
+        with self._verts_lock:
+            if end is self.v1:
+                return self.v2
+            if end is self.v2:
+                return self.v1
 
         return None

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -7,6 +7,7 @@ Holds the Universe class.
 from __future__ import annotations
 
 import types
+import threading
 from typing import TYPE_CHECKING
 
 from edgegraph.structure import base, vertex
@@ -211,6 +212,8 @@ class Universe(vertex.Vertex):
             self._laws = UniverseLaws(applies_to=self)
         self._laws.applies_to = self
 
+        self._verts_lock = threading._PyRLock()
+
         #: Internal set of vertices
         self._vertices: list[Vertex] = []
         if vertices is not None:
@@ -233,7 +236,8 @@ class Universe(vertex.Vertex):
         :return: vertices belonging to this universe, ordered by insertion
            order.
         """
-        return list(self._vertices)
+        with self._verts_lock:
+            return list(self._vertices)
 
     def add_vertex(self, vert: vertex.Vertex):
         """
@@ -250,12 +254,13 @@ class Universe(vertex.Vertex):
 
         :param vert: the vertex to be added
         """
-        if vert in self._vertices:
-            return
+        with self._verts_lock:
+            if vert in self._vertices:
+                return
 
-        self._vertices.append(vert)
-        if self not in vert.universes:
-            vert.add_to_universe(self)
+            self._vertices.append(vert)
+            if self not in vert.universes:
+                vert.add_to_universe(self)
 
     def remove_vertex(self, vert: vertex.Vertex):
         """
@@ -267,9 +272,10 @@ class Universe(vertex.Vertex):
 
         :param vert: the vertex to be removed
         """
-        self._vertices.remove(vert)
-        if self in vert.universes:
-            vert.remove_from_universe(self)
+        with self._verts_lock:
+            self._vertices.remove(vert)
+            if self in vert.universes:
+                vert.remove_from_universe(self)
 
     @property
     def laws(self) -> UniverseLaws | None:

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -6,8 +6,8 @@ Holds the Universe class.
 
 from __future__ import annotations
 
-import types
 import threading
+import types
 from typing import TYPE_CHECKING
 
 from edgegraph.structure import base, vertex

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -144,9 +144,12 @@ class Vertex(base.BaseObject):
         if needed.
 
         :param universe: the new universe to add this object to
-        :concurrency: **Unsafe**
+        :concurrency: Thread-safe.
         """
         super().add_to_universe(universe)
+
+        # both universe.vertices and universe.add_vertex use internal locks, so
+        # these calls are thread-safe by nature
         if self not in universe.vertices:
             universe.add_vertex(self)
 
@@ -283,8 +286,11 @@ class Vertex(base.BaseObject):
 
         :param universe: the universe that this vertex will be removed from
         :raises KeyError: if this object is not present in the given universe
-        :concurrency: **Unsafe**
+        :concurrency: Thread-safe.
         """
         super().remove_from_universe(universe)
+
+        # both universe.vertices and universe.remove_vertex use internal locks,
+        # so these calls are thread-safe with no extra action on our part
         if self in universe.vertices:
             universe.remove_vertex(self)

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
+import threading
 
 from edgegraph.structure import base
 
@@ -34,6 +35,7 @@ class Vertex(base.BaseObject):
 
     _QA_NB_INVALID: object = object()
     _CACHE_STATS: ClassVar[dict[int, list[int]]] = {}
+    _CACHE_STATS_LOCK = threading.RLock()
 
     @classmethod
     def total_cache_stats(cls) -> str:
@@ -57,11 +59,12 @@ class Vertex(base.BaseObject):
 
         if cls.NEIGHBOR_CACHING:
             totals = [0, 0, 0, 0]
-            for stat in cls._CACHE_STATS.values():
-                totals[0] += stat[0]
-                totals[1] += stat[1]
-                totals[2] += stat[2]
-                totals[3] += stat[3]
+            with cls._CACHE_STATS_LOCK:
+                for stat in cls._CACHE_STATS.values():
+                    totals[0] += stat[0]
+                    totals[1] += stat[1]
+                    totals[2] += stat[2]
+                    totals[3] += stat[3]
 
             lines.append("=== CACHE STATISTICS OVERALL ===")
             lines.append(f"Size:          {len(Vertex._CACHE_STATS)}")
@@ -98,22 +101,28 @@ class Vertex(base.BaseObject):
         """
         super().__init__(uid=uid, attributes=attributes, universes=universes)
 
-        self._CACHE_STATS.update({self.uid: [0, 0, 0, 0]})
+        with self._CACHE_STATS_LOCK:
+            self._CACHE_STATS.update({self.uid: [0, 0, 0, 0]})
+
+        self._links_lock = threading.RLock()
+        self._qanb_cache_lock = threading.RLock()
 
         #: Links that this vertex is associated with
         #:
         #: This is a list of links that include this vertex as one of the
         #: linked vertices.
-        self._links: list[Link] = []
-        if links is not None:
-            for link in links:
-                self.add_to_link(link)
+        with self._links_lock:
+            self._links: list[Link] = []
+            if links is not None:
+                for link in links:
+                    self.add_to_link(link)
 
         # ensure that we add ourselves to the universes given
         for uni in self.universes:
             uni.add_vertex(self)
 
-        self.__qa_nb_cache: dict[tuple[Any, ...], list[Vertex]] = {}
+        with self._qanb_cache_lock:
+            self.__qa_nb_cache: dict[tuple[Any, ...], list[Vertex]] = {}
 
     def add_to_universe(self, universe: Universe) -> None:
         """
@@ -140,7 +149,8 @@ class Vertex(base.BaseObject):
         A tuple is given specifically to prevent the addition or removal of
         link objects using this attribute; it is intended to be immutable.
         """
-        return tuple(self._links)
+        with self._links_lock:
+            return tuple(self._links)
 
     def _qa_neighbors_get(self, *args):
         """
@@ -159,13 +169,14 @@ class Vertex(base.BaseObject):
         if not self.NEIGHBOR_CACHING:
             return self._QA_NB_INVALID
 
-        if args in self.__qa_nb_cache:
-            self._CACHE_STATS[self.uid][0] += 1
+        with self._qanb_cache_lock, self._CACHE_STATS_LOCK:
+            if args in self.__qa_nb_cache:
+                self._CACHE_STATS[self.uid][0] += 1
 
-            return self.__qa_nb_cache[args]
+                return self.__qa_nb_cache[args]
 
-        self._CACHE_STATS[self.uid][1] += 1
-        return self._QA_NB_INVALID
+            self._CACHE_STATS[self.uid][1] += 1
+            return self._QA_NB_INVALID
 
     def _qa_neighbors_invalidate(self):
         """
@@ -180,8 +191,10 @@ class Vertex(base.BaseObject):
         """
         if not self.NEIGHBOR_CACHING:
             return
-        self._CACHE_STATS[self.uid][2] += 1
-        self.__qa_nb_cache = {}
+
+        with self._qanb_cache_lock, self._CACHE_STATS_LOCK:
+            self._CACHE_STATS[self.uid][2] += 1
+            self.__qa_nb_cache = {}
 
     def _qa_neighbors_insert(self, answer, *args):
         """
@@ -197,8 +210,10 @@ class Vertex(base.BaseObject):
         """
         if not self.NEIGHBOR_CACHING:
             return
-        self._CACHE_STATS[self.uid][3] += 1
-        self.__qa_nb_cache[args] = answer
+
+        with self._qanb_cache_lock, self._CACHE_STATS_LOCK:
+            self._CACHE_STATS[self.uid][3] += 1
+            self.__qa_nb_cache[args] = answer
 
     def add_to_link(self, link: Link):
         """
@@ -219,10 +234,11 @@ class Vertex(base.BaseObject):
 
         :param link: the link to add this vertex to
         """
-        if link not in self._links:
-            self._links.append(link)
-            if self not in link.vertices:
-                link.add_vertex(self)
+        with self._links_lock:
+            if link not in self._links:
+                self._links.append(link)
+                if self not in link.vertices:
+                    link.add_vertex(self)
 
         self._qa_neighbors_invalidate()
 
@@ -233,9 +249,10 @@ class Vertex(base.BaseObject):
         :param link: the link to remove this vertex from.
         """
 
-        if link in self._links:
-            self._links.remove(link)
-            link.unlink_from(self)
+        with self._links_lock:
+            if link in self._links:
+                self._links.remove(link)
+                link.unlink_from(self)
 
         self._qa_neighbors_invalidate()
 

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -6,9 +6,9 @@ Holds the Vertex class.
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
-import threading
 
 from edgegraph.structure import base
 
@@ -37,8 +37,7 @@ class Vertex(base.BaseObject):
     _CACHE_STATS: ClassVar[dict[int, list[int]]] = {}
 
     # would love to use regular threading.RLock() here, but it breaks dill...
-    # https://github.com/uqfoundation/dill/issues/321
-    # https://github.com/fal-ai/dbt-fal/pull/850
+    # https://github.com/mishaturnbull/edgegraph/issues/118
     _CACHE_STATS_LOCK = threading._PyRLock()
 
     @classmethod
@@ -110,8 +109,7 @@ class Vertex(base.BaseObject):
 
         # would love to use regular threading.RLock() here, but it breaks
         # dill...
-        # https://github.com/uqfoundation/dill/issues/321
-        # https://github.com/fal-ai/dbt-fal/pull/850
+        # https://github.com/mishaturnbull/edgegraph/issues/118
         self._links_lock = threading._PyRLock()
         self._qanb_cache_lock = threading._PyRLock()
 

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -35,7 +35,11 @@ class Vertex(base.BaseObject):
 
     _QA_NB_INVALID: object = object()
     _CACHE_STATS: ClassVar[dict[int, list[int]]] = {}
-    _CACHE_STATS_LOCK = threading.RLock()
+
+    # would love to use regular threading.RLock() here, but it breaks dill...
+    # https://github.com/uqfoundation/dill/issues/321
+    # https://github.com/fal-ai/dbt-fal/pull/850
+    _CACHE_STATS_LOCK = threading._PyRLock()
 
     @classmethod
     def total_cache_stats(cls) -> str:
@@ -104,8 +108,12 @@ class Vertex(base.BaseObject):
         with self._CACHE_STATS_LOCK:
             self._CACHE_STATS.update({self.uid: [0, 0, 0, 0]})
 
-        self._links_lock = threading.RLock()
-        self._qanb_cache_lock = threading.RLock()
+        # would love to use regular threading.RLock() here, but it breaks
+        # dill...
+        # https://github.com/uqfoundation/dill/issues/321
+        # https://github.com/fal-ai/dbt-fal/pull/850
+        self._links_lock = threading._PyRLock()
+        self._qanb_cache_lock = threading._PyRLock()
 
         #: Links that this vertex is associated with
         #:

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -57,6 +57,7 @@ class Vertex(base.BaseObject):
 
         :return: Human-readable string indicating size, hits, misses,
            invalidations, and insertions to the vertex neighbor cache.
+        :concurrency: Thread-safe
         """
         lines = []
 
@@ -96,6 +97,7 @@ class Vertex(base.BaseObject):
         provided to this method.
 
         :param links: iterable of link objects to associate this vertex with
+        :concurrency: Thread-safe
 
         .. seealso::
 
@@ -142,6 +144,7 @@ class Vertex(base.BaseObject):
         if needed.
 
         :param universe: the new universe to add this object to
+        :concurrency: **Unsafe**
         """
         super().add_to_universe(universe)
         if self not in universe.vertices:
@@ -154,6 +157,8 @@ class Vertex(base.BaseObject):
 
         A tuple is given specifically to prevent the addition or removal of
         link objects using this attribute; it is intended to be immutable.
+
+        :concurrency: Thread-safe
         """
         with self._links_lock:
             return tuple(self._links)
@@ -171,6 +176,7 @@ class Vertex(base.BaseObject):
 
         :param args: Arguments passed to neighbors() function.
         :return: Cached data if available, else :py:attr:`_QA_NB_INVALID`.
+        :concurrency: Thread-safe
         """
         if not self.NEIGHBOR_CACHING:
             return self._QA_NB_INVALID
@@ -194,6 +200,8 @@ class Vertex(base.BaseObject):
         This MUST be called when the vertex's neighbors are modified in any way
         -- linked, unlinked, or anything else, to maintain cache integrity and
         prevent stale data.
+
+        :concurrency: Thread-safe
         """
         if not self.NEIGHBOR_CACHING:
             return
@@ -213,6 +221,7 @@ class Vertex(base.BaseObject):
 
         :param answer: the neighbors of this object
         :param *args: Arguments passed to the neighbors() function
+        :concurrency: Thread-safe
         """
         if not self.NEIGHBOR_CACHING:
             return
@@ -239,6 +248,7 @@ class Vertex(base.BaseObject):
            duplicate links are allowed, ``is`` duplicate links are ignored.
 
         :param link: the link to add this vertex to
+        :concurrency: Thread-safe
         """
         with self._links_lock:
             if link not in self._links:
@@ -253,6 +263,7 @@ class Vertex(base.BaseObject):
         Remove this vertex from a link.
 
         :param link: the link to remove this vertex from.
+        :concurrency: Thread-safe
         """
 
         with self._links_lock:
@@ -272,6 +283,7 @@ class Vertex(base.BaseObject):
 
         :param universe: the universe that this vertex will be removed from
         :raises KeyError: if this object is not present in the given universe
+        :concurrency: **Unsafe**
         """
         super().remove_from_universe(universe)
         if self in universe.vertices:

--- a/tests/integration/test_performance.py
+++ b/tests/integration/test_performance.py
@@ -142,7 +142,7 @@ def test_trav_versus(graph_clrs09_22_6, trav):
     Test traversal methods on the same graph and time results.
     """
     howmany = 100000
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
     fname = trav.__name__
     times = [None] * howmany
 

--- a/tests/integration/test_pickling.py
+++ b/tests/integration/test_pickling.py
@@ -63,7 +63,7 @@ def test_p_up_large(straightline_graph_1k_directed, protocol):
     test_rcr_depth = sys.getrecursionlimit()
     LOG.debug(f"test_rcr_depth = {test_rcr_depth}")
 
-    uni, verts = straightline_graph_1k_directed
+    uni, _ = straightline_graph_1k_directed
 
     try:
         serial = nrpickler.dumps(uni, protocol=protocol)
@@ -305,7 +305,7 @@ def test_p_up_file(protocol, tmp_path, straightline_graph_1k_directed):
         nrpickler.dump((uni, verts), wfp)
 
     with open(fname, "rb") as rfp:
-        puni, pverts = pickle.load(rfp)
+        _, pverts = pickle.load(rfp)
 
     assert len(pverts) == len(verts), "Wrong length of vertices"
 

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -22,7 +22,7 @@ travs = [
     breadthfirst.bft,
 ]
 
-if sys.version_info <= (3, 13):
+if sys.version_info >= (3, 13):
     N_WORKERS = min(32, (os.process_cpu_count() or 1) + 4)
 else:
     N_WORKERS = min(32, len(os.sched_getaffinity(0)))

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -13,7 +13,7 @@ from concurrent import futures
 import pytest
 
 from edgegraph.builder import explicit
-from edgegraph.structure import DirectedEdge
+from edgegraph.structure import DirectedEdge, Universe, BaseObject
 from edgegraph.traversal import breadthfirst, depthfirst, helpers
 
 travs = [
@@ -156,3 +156,56 @@ def test_concurrent_futures_build_slow(graph_clrs09_22_6):
     n_tries = 128
     for _ in range(n_tries):
         routine_cfb(graph_clrs09_22_6)
+
+
+def routine_universes():
+    """
+    Test routine for baseobject-in-universe thread safety.
+    """
+    uni = Universe()
+    bos = [BaseObject()] * 32
+
+    def proc_add(barrier_add, uni, bos):
+        barrier_add.wait()
+        for bo in bos:
+            bo.add_to_universe(uni)
+
+    def proc_rem(barrier_rem, uni, bos):
+        barrier_rem.wait()
+        for bo in bos:
+            bo.remove_from_universe(uni)
+
+    all_futures = []
+
+    with futures.ThreadPoolExecutor(max_workers=N_WORKERS * 2) as executor:
+        barrier_add = threading.Barrier(N_WORKERS * 2)
+        barrier_rem = threading.Barrier(N_WORKERS * 2)
+
+        for _ in range(N_WORKERS * 2):
+            future = executor.submit(proc_add, barrier_add, uni, bos)
+            all_futures.append(future)
+
+        for future in futures.as_completed(all_futures):
+            future.result()
+
+        for bo in bos:
+            assert bo.universes == [uni], "Did not add correctly!"
+
+        all_futures = []
+        for _ in range(N_WORKERS * 2):
+            future = executor.submit(proc_rem, barrier_rem, uni, bos)
+            all_futures.append(future)
+
+        for future in futures.as_completed(all_futures):
+            future.result()
+
+    for i, bo in enumerate(bos):
+        assert bo.universes == [], "Wrong universes!"
+
+
+@pytest.mark.timeout(10)
+def test_concurrent_futures_universe_fast():
+    t_start = time.monotonic_ns()
+    while time.monotonic_ns() - t_start < 5 * NANO:
+        routine_universes()
+

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -213,6 +213,7 @@ def test_concurrent_futures_universe_fast():
     while time.monotonic_ns() - t_start < 5 * NANO:
         routine_universes()
 
+
 @pytest.mark.slow
 def test_concurrent_futures_universe_slow():
     """

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -64,6 +64,7 @@ def routine_cft(graph_clrs09_22_6, trav, singlethread_answer):
             )
 
 
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize("trav", travs)
 def test_concurrent_futures_trav_fast(graph_clrs09_22_6, trav):
     """
@@ -135,6 +136,7 @@ def routine_cfb(graph_clrs09_22_6):
     )
 
 
+@pytest.mark.timeout(10)
 def test_concurrent_futures_build_fast(graph_clrs09_22_6):
     """
     Ensure writing to a graph is safe across many threads concurrently for 5
@@ -209,4 +211,14 @@ def test_concurrent_futures_universe_fast():
     """
     t_start = time.monotonic_ns()
     while time.monotonic_ns() - t_start < 5 * NANO:
+        routine_universes()
+
+@pytest.mark.slow
+def test_concurrent_futures_universe_slow():
+    """
+    Ensure BaseObject and Universe linkages are safe across many threads
+    concurrently; test runs 128 times.
+    """
+    n_tries = 128
+    for _ in range(n_tries):
         routine_universes()

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -13,7 +13,7 @@ from concurrent import futures
 import pytest
 
 from edgegraph.builder import explicit
-from edgegraph.structure import DirectedEdge, Universe, BaseObject
+from edgegraph.structure import BaseObject, DirectedEdge, Universe
 from edgegraph.traversal import breadthfirst, depthfirst, helpers
 
 travs = [
@@ -106,7 +106,7 @@ def routine_cfb(graph_clrs09_22_6):
     function for easier variability in how many times this routine is run per
     unit test.
     """
-    uni, verts = graph_clrs09_22_6
+    _, verts = graph_clrs09_22_6
 
     def proc(barrier):
         barrier.wait()
@@ -140,7 +140,6 @@ def test_concurrent_futures_build_fast(graph_clrs09_22_6):
     Ensure writing to a graph is safe across many threads concurrently for 5
     seconds.
     """
-    uni, verts = graph_clrs09_22_6
     t_start = time.monotonic_ns()
     while time.monotonic_ns() - t_start < 5 * NANO:
         routine_cfb(graph_clrs09_22_6)
@@ -152,7 +151,6 @@ def test_concurrent_futures_build_slow(graph_clrs09_22_6):
     Ensure writing to a graph is safe across many threads concurrently 128
     times.
     """
-    uni, verts = graph_clrs09_22_6
     n_tries = 128
     for _ in range(n_tries):
         routine_cfb(graph_clrs09_22_6)
@@ -199,13 +197,16 @@ def routine_universes():
         for future in futures.as_completed(all_futures):
             future.result()
 
-    for i, bo in enumerate(bos):
+    for bo in bos:
         assert bo.universes == [], "Wrong universes!"
 
 
 @pytest.mark.timeout(10)
 def test_concurrent_futures_universe_fast():
+    """
+    Ensure BaseObject and Universe linkages are handled in a thread-safe
+    manner, concurreently for 5 seconds (this is the fast version of the test).
+    """
     t_start = time.monotonic_ns()
     while time.monotonic_ns() - t_start < 5 * NANO:
         routine_universes()
-

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -7,6 +7,7 @@ Ensure graph operations are thread-safe.
 from concurrent import futures
 import os
 import threading
+import time
 
 import pytest
 
@@ -21,6 +22,7 @@ travs = [
 ]
 
 N_WORKERS = min(32, (os.process_cpu_count() or 1) + 4)
+NANO = 1_000_000_000
 
 
 def barricaded_call(barrier, func, *args, **kwargs):
@@ -30,11 +32,53 @@ def barricaded_call(barrier, func, *args, **kwargs):
     barrier.wait()
     return func(*args, **kwargs)
 
+def routine_cft(graph_clrs09_22_6, trav, singlethread_answer):
+    uni, verts = graph_clrs09_22_6
+    all_futures = []
+
+    with futures.ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+        # use a barrier to ensure all threads are started at the same time
+        # -- increase concurrent accesses
+        barrier = threading.Barrier(N_WORKERS)
+
+        for _ in range(N_WORKERS):
+            future = executor.submit(
+                barricaded_call, barrier, trav, uni, verts[0]
+            )
+            all_futures.append(future)
+
+        for future in futures.as_completed(all_futures):
+            try:
+                data = future.result()
+            except Exception as exc:
+                raise exc
+            else:
+                assert data == singlethread_answer, (
+                    "Did not get the same answer as single-threaded run!"
+                )
 
 @pytest.mark.parametrize("trav", travs)
-def test_concurrent_futures_trav(graph_clrs09_22_6, trav):
+def test_concurrent_futures_trav_fast(graph_clrs09_22_6, trav):
     """
-    Ensure reading from a graph is safe across many threads concurrently.
+    Ensure reading from a graph is safe across many threads concurrently for 5
+    seconds.
+
+    Creates a graph, then tries to traverse it in a multi-threaded manner many
+    times to induce any simultaneous-access issues.
+    """
+    uni, verts = graph_clrs09_22_6
+    singlethread_answer = trav(uni, verts[0])
+    t_start = time.monotonic_ns()
+
+    while time.monotonic_ns() - t_start < 5 * NANO:
+        routine_cft(graph_clrs09_22_6, trav, singlethread_answer)
+
+@pytest.mark.slow
+@pytest.mark.parametrize("trav", travs)
+def test_concurrent_futures_trav_slow(graph_clrs09_22_6, trav):
+    """
+    Ensure reading from a graph is safe across many threads concurrently, 512
+    times.
 
     Creates a graph, then tries to traverse it in a multi-threaded manner many
     times to induce any simultaneous-access issues.
@@ -45,37 +89,11 @@ def test_concurrent_futures_trav(graph_clrs09_22_6, trav):
     singlethread_answer = trav(uni, verts[0])
 
     for _ in range(n_tries):
-        all_futures = []
-
-        with futures.ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
-            # use a barrier to ensure all threads are started at the same time
-            # -- increase concurrent accesses
-            barrier = threading.Barrier(N_WORKERS)
-
-            for _ in range(N_WORKERS):
-                future = executor.submit(
-                    barricaded_call, barrier, trav, uni, verts[0]
-                )
-                all_futures.append(future)
-
-            for future in futures.as_completed(all_futures):
-                try:
-                    data = future.result()
-                except Exception as exc:
-                    raise exc
-                else:
-                    assert data == singlethread_answer, (
-                        "Did not get the same answer as single-threaded run!"
-                    )
+        routine_cft(graph_clrs09_22_6, trav, singlethread_answer)
 
 
-def test_concurrent_futures_build(graph_clrs09_22_6):
-    """
-    Ensure writing to a graph is safe across many threads concurrently.
-    """
+def routine_cfb(graph_clrs09_22_6):
     uni, verts = graph_clrs09_22_6
-
-    n_tries = 256
 
     def proc(barrier):
         barrier.wait()
@@ -83,27 +101,47 @@ def test_concurrent_futures_build(graph_clrs09_22_6):
         helpers.neighbors(verts[0])
         assert verts[1] in helpers.neighbors(verts[0])
 
+    all_futures = []
+
+    with futures.ThreadPoolExecutor(max_workers=N_WORKERS * 2) as executor:
+        # use a barrier to ensure all threads are started at the same time
+        # -- increase concurrent accesses
+        barrier = threading.Barrier(N_WORKERS * 2)
+
+        for _ in range(N_WORKERS * 2):
+            future = executor.submit(proc, barrier)
+            all_futures.append(future)
+
+        links = []
+        for future in futures.as_completed(all_futures):
+            try:
+                data = future.result()
+            except Exception as exc:
+                raise exc
+            else:
+                links.append(data)
+
+    assert len(links) == N_WORKERS * 2, (
+        "Did not create correct amount of links!"
+    )
+
+def test_concurrent_futures_build_fast(graph_clrs09_22_6):
+    """
+    Ensure writing to a graph is safe across many threads concurrently for 5
+    seconds.
+    """
+    uni, verts = graph_clrs09_22_6
+    t_start = time.monotonic_ns()
+    while time.monotonic_ns() - t_start < 5 * NANO:
+        routine_cfb(graph_clrs09_22_6)
+
+@pytest.mark.slow
+def test_concurrent_futures_build_slow(graph_clrs09_22_6):
+    """
+    Ensure writing to a graph is safe across many threads concurrently 128
+    times.
+    """
+    uni, verts = graph_clrs09_22_6
+    n_tries = 128
     for _ in range(n_tries):
-        all_futures = []
-
-        with futures.ThreadPoolExecutor(max_workers=N_WORKERS * 2) as executor:
-            # use a barrier to ensure all threads are started at the same time
-            # -- increase concurrent accesses
-            barrier = threading.Barrier(N_WORKERS * 2)
-
-            for _ in range(N_WORKERS * 2):
-                future = executor.submit(proc, barrier)
-                all_futures.append(future)
-
-            links = []
-            for future in futures.as_completed(all_futures):
-                try:
-                    data = future.result()
-                except Exception as exc:
-                    raise exc
-                else:
-                    links.append(data)
-
-        assert len(links) == N_WORKERS * 2, (
-            "Did not create correct amount of links!"
-        )
+        routine_cfb(graph_clrs09_22_6)

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+"""
+Ensure graph operations are thread-safe.
+"""
+
+from concurrent import futures
+import os
+import threading
+
+import pytest
+
+from edgegraph.traversal import helpers, breadthfirst, depthfirst, breadthfirst
+from edgegraph.structure import DirectedEdge
+from edgegraph.builder import explicit
+
+travs = [
+    depthfirst.dft_recursive,
+    depthfirst.dft_iterative,
+    breadthfirst.bft,
+]
+
+N_WORKERS = min(32, (os.process_cpu_count() or 1) + 4)
+
+
+def barricaded_call(barrier, func, *args, **kwargs):
+    """
+    Simple wrapper around a barricaded function call.
+    """
+    barrier.wait()
+    return func(*args, **kwargs)
+
+
+@pytest.mark.parametrize("trav", travs)
+def test_concurrent_futures_trav(graph_clrs09_22_6, trav):
+    """
+    Ensure reading from a graph is safe across many threads concurrently.
+
+    Creates a graph, then tries to traverse it in a multi-threaded manner many
+    times to induce any simultaneous-access issues.
+    """
+    uni, verts = graph_clrs09_22_6
+
+    n_tries = 512
+    singlethread_answer = trav(uni, verts[0])
+
+    for _ in range(n_tries):
+        all_futures = []
+
+        with futures.ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+            # use a barrier to ensure all threads are started at the same time
+            # -- increase concurrent accesses
+            barrier = threading.Barrier(N_WORKERS)
+
+            for _ in range(N_WORKERS):
+                future = executor.submit(
+                    barricaded_call, barrier, trav, uni, verts[0]
+                )
+                all_futures.append(future)
+
+            for future in futures.as_completed(all_futures):
+                try:
+                    data = future.result()
+                except Exception as exc:
+                    raise exc
+                else:
+                    assert data == singlethread_answer, (
+                        "Did not get the same answer as single-threaded run!"
+                    )
+
+
+def test_concurrent_futures_build(graph_clrs09_22_6):
+    """
+    Ensure writing to a graph is safe across many threads concurrently.
+    """
+    uni, verts = graph_clrs09_22_6
+
+    n_tries = 256
+
+    def proc(barrier):
+        barrier.wait()
+        explicit.link_from_to(verts[0], DirectedEdge, verts[1])
+        helpers.neighbors(verts[0])
+        assert verts[1] in helpers.neighbors(verts[0])
+
+    for _ in range(n_tries):
+        all_futures = []
+
+        with futures.ThreadPoolExecutor(max_workers=N_WORKERS * 2) as executor:
+            # use a barrier to ensure all threads are started at the same time
+            # -- increase concurrent accesses
+            barrier = threading.Barrier(N_WORKERS * 2)
+
+            for _ in range(N_WORKERS * 2):
+                future = executor.submit(proc, barrier)
+                all_futures.append(future)
+
+            links = []
+            for future in futures.as_completed(all_futures):
+                try:
+                    data = future.result()
+                except Exception as exc:
+                    raise exc
+                else:
+                    links.append(data)
+
+        assert len(links) == N_WORKERS * 2, (
+            "Did not create correct amount of links!"
+        )

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -4,16 +4,16 @@
 Ensure graph operations are thread-safe.
 """
 
-from concurrent import futures
 import os
 import threading
 import time
+from concurrent import futures
 
 import pytest
 
-from edgegraph.traversal import helpers, breadthfirst, depthfirst, breadthfirst
-from edgegraph.structure import DirectedEdge
 from edgegraph.builder import explicit
+from edgegraph.structure import DirectedEdge
+from edgegraph.traversal import breadthfirst, depthfirst, helpers
 
 travs = [
     depthfirst.dft_recursive,
@@ -32,7 +32,13 @@ def barricaded_call(barrier, func, *args, **kwargs):
     barrier.wait()
     return func(*args, **kwargs)
 
+
 def routine_cft(graph_clrs09_22_6, trav, singlethread_answer):
+    """
+    Test routine for concurrent-futures-trav tests.  Isolated into its own
+    function for easier variability in how many times this routine is run per
+    unit test.
+    """
     uni, verts = graph_clrs09_22_6
     all_futures = []
 
@@ -48,14 +54,11 @@ def routine_cft(graph_clrs09_22_6, trav, singlethread_answer):
             all_futures.append(future)
 
         for future in futures.as_completed(all_futures):
-            try:
-                data = future.result()
-            except Exception as exc:
-                raise exc
-            else:
-                assert data == singlethread_answer, (
-                    "Did not get the same answer as single-threaded run!"
-                )
+            data = future.result()
+            assert data == singlethread_answer, (
+                "Did not get the same answer as single-threaded run!"
+            )
+
 
 @pytest.mark.parametrize("trav", travs)
 def test_concurrent_futures_trav_fast(graph_clrs09_22_6, trav):
@@ -72,6 +75,7 @@ def test_concurrent_futures_trav_fast(graph_clrs09_22_6, trav):
 
     while time.monotonic_ns() - t_start < 5 * NANO:
         routine_cft(graph_clrs09_22_6, trav, singlethread_answer)
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize("trav", travs)
@@ -93,6 +97,11 @@ def test_concurrent_futures_trav_slow(graph_clrs09_22_6, trav):
 
 
 def routine_cfb(graph_clrs09_22_6):
+    """
+    Test routine for concurrent-futures-build tests.  Isolated into its own
+    function for easier variability in how many times this routine is run per
+    unit test.
+    """
     uni, verts = graph_clrs09_22_6
 
     def proc(barrier):
@@ -114,16 +123,13 @@ def routine_cfb(graph_clrs09_22_6):
 
         links = []
         for future in futures.as_completed(all_futures):
-            try:
-                data = future.result()
-            except Exception as exc:
-                raise exc
-            else:
-                links.append(data)
+            data = future.result()
+            links.append(data)
 
     assert len(links) == N_WORKERS * 2, (
         "Did not create correct amount of links!"
     )
+
 
 def test_concurrent_futures_build_fast(graph_clrs09_22_6):
     """
@@ -134,6 +140,7 @@ def test_concurrent_futures_build_fast(graph_clrs09_22_6):
     t_start = time.monotonic_ns()
     while time.monotonic_ns() - t_start < 5 * NANO:
         routine_cfb(graph_clrs09_22_6)
+
 
 @pytest.mark.slow
 def test_concurrent_futures_build_slow(graph_clrs09_22_6):

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -5,6 +5,7 @@ Ensure graph operations are thread-safe.
 """
 
 import os
+import sys
 import threading
 import time
 from concurrent import futures
@@ -21,7 +22,10 @@ travs = [
     breadthfirst.bft,
 ]
 
-N_WORKERS = min(32, (os.process_cpu_count() or 1) + 4)
+if sys.version_info <= (3, 13):
+    N_WORKERS = min(32, (os.process_cpu_count() or 1) + 4)
+else:
+    N_WORKERS = min(32, len(os.sched_getaffinity(0)))
 NANO = 1_000_000_000
 
 

--- a/tests/interact.py
+++ b/tests/interact.py
@@ -20,7 +20,7 @@ from edgegraph.output import plaintext, pyvis
 from edgegraph.output import plantuml as pu
 
 # this is meant to be an interactive script.
-# ruff: noqa: T201, T203
+# ruff: noqa: T201
 
 
 def main():

--- a/tests/output/test_plantuml_src.py
+++ b/tests/output/test_plantuml_src.py
@@ -94,7 +94,7 @@ def test_plantuml_class_option_resolution_fail(graph_clrs09_22_6):
     del opts[Vertex]
 
     with pytest.raises(
-        ValueError, match="Cannot identify (useful )?superclass of"
+        ValueError, match=r"Cannot identify (useful )?superclass of"
     ):
         plantuml.render_to_plantuml_src(graph_clrs09_22_6[0], opts)
 

--- a/tests/output/test_pyvis_not_installed.py
+++ b/tests/output/test_pyvis_not_installed.py
@@ -14,7 +14,7 @@ import pytest
 # this test module does a few unorthodox imports -- but, that's the point of
 # this single test isolated in its own module.  we don't want the "gonna break
 # everything" test to, well, break everything *else*
-# ruff: noqa: F401
+# ruff: noqa: F401, PLC0415
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/pathfinding/test_single_pair_shortest_path_dijkstra.py
+++ b/tests/pathfinding/test_single_pair_shortest_path_dijkstra.py
@@ -42,7 +42,7 @@ def test_spsp_dijkstra_weighted_nochange(graph_cheapest_is_shortest):
 def test_spsp_dijkstra_weighted_diff(graph_cheapest_is_longest):
     r"""
     Ensure that graphs with a custom weight function A.) work, and B.) solve as
-    expected in the case where :math:`weight(u, v) \\neq  1`.
+    expected in the case where :math:`weight(u, v) \neq  1`.
     """
     uni, verts = graph_cheapest_is_longest
 

--- a/tests/structure/test_base.py
+++ b/tests/structure/test_base.py
@@ -200,11 +200,9 @@ def test_base_obj_universes():
     assert uni not in bo.universes, "remove_from_universe didn't!"
     assert uni not in bo._universes, "remove_from_universe didn't!"
 
-    # should fail, as the universe has already been removed.  when trying to
-    # remove an object from a list that does not contain it, you get a
-    # ValueError
-    with pytest.raises(ValueError, match="not in list"):
-        bo.remove_from_universe(uni)
+    # call it again to make sure we don't get any errors (this used to raise a
+    # ValueError)
+    bo.remove_from_universe(uni)
 
 
 def test_base_obj_init_universes_list():

--- a/tests/structure/test_importability.py
+++ b/tests/structure/test_importability.py
@@ -6,7 +6,7 @@ Unit tests to ensure module structure is operable.
 
 # disable import-related checks; everything imported here is unused.  that's
 # fine.
-# ruff: noqa: F401
+# ruff: noqa: F401, PLC0415
 
 
 def test_full_qual_imports():


### PR DESCRIPTION
**Category**

This PR is a

* [x] Bugfix
  * [ ] Hotfix merging directly into `master`
* [ ] New feature
* [ ] Version release
* [ ] General code quality improvement
* [ ] Something else: (please describe)

**Description**

Core graph state is now thread-safe for read and write operations.

**NOTE**:  1 API change:

* `BaseObject.remove_from_universe()` no longer throws a `ValueError` if the base object is already not present in the specified universe.  Instead, it silently takes no action.

**Related issues**

Fixes #116.

*Creates* #118.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
  * [ ] For release PRs, the changelog has been updated
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

