### PR TITLE
Expose version constants at module level

### DIFF
--- a/edgegraph/__init__.py
+++ b/edgegraph/__init__.py
@@ -3,3 +3,9 @@
 """
 Main module for edgegraph.
 """
+
+# import all version constants so they're accessible via direct
+# edgegraph.__version__
+# i know... import star... but the version submodule has careful handling to
+# only export names defined in that file
+from edgegraph.version import *  # noqa: F403

--- a/edgegraph/version.py
+++ b/edgegraph/version.py
@@ -3,6 +3,17 @@
 """
 Define version information for edgegraph.
 
+You may also import the following constants from the :py:mod:`edgegraph` module
+directly:
+
+.. code-block:: python
+
+   import edgegraph
+   from edgegraph import version
+
+   edgegraph.VERSION_MAJOR == version.VERSION_MAJOR  # True
+   edgegraph.__version__ == version.__version__  # True
+
 This is the ONLY place version information should be updated!!
 """
 
@@ -25,6 +36,9 @@ VERSION_MINOR = 11
 #: :type: int
 VERSION_PATCH = 0
 
+#: complete module version number
+#:
+#: :type: str
 __version__ = f"{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}"
 
 # Figure out what variables have been added, and export them to __all__

--- a/edgegraph/version.py
+++ b/edgegraph/version.py
@@ -6,6 +6,10 @@ Define version information for edgegraph.
 This is the ONLY place version information should be updated!!
 """
 
+# Take a snapshot of the directory before, to be used for determining what
+# names are added
+_dir_before = set(dir())
+
 #: major version number (the X in vX.Y.Z)
 #:
 #: :type: int
@@ -22,3 +26,8 @@ VERSION_MINOR = 11
 VERSION_PATCH = 0
 
 __version__ = f"{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}"
+
+# Figure out what variables have been added, and export them to __all__
+_dir_after = set(dir())
+_all = _dir_after - _dir_before - {"_dir_before", "_dir_after"}
+__all__ = list(_all)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ Homepage = "https://edgegraph.readthedocs.io/en/latest/"
 Repository = "https://github.com/mishaturnbull/edgegraph"
 
 [tool.setuptools.dynamic]
-version = {attr = "edgegraph.version.__version__"}
+version = {attr = "edgegraph.__version__"}
 
 [tool.pytest.ini_options]
 markers = [

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,7 +6,7 @@ Ensure the versioning constants are valid.
 
 import re
 
-from edgegraph import version
+import edgegraph
 
 
 def test_version():
@@ -18,15 +18,15 @@ def test_version():
     """
 
     for attr in [
-        version.VERSION_MAJOR,
-        version.VERSION_MINOR,
-        version.VERSION_PATCH,
+        edgegraph.VERSION_MAJOR,
+        edgegraph.VERSION_MINOR,
+        edgegraph.VERSION_PATCH,
     ]:
         assert isinstance(attr, int)
         assert attr >= 0
 
     # 5 is the minimum possible length, of "0.0.0"
-    assert len(version.__version__) >= 5
+    assert len(edgegraph.__version__) >= 5
 
 
 def test_python_version_compliance():
@@ -41,4 +41,4 @@ def test_python_version_compliance():
         r'^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)"'
         r"(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$"
     )
-    assert re.match(ptrn, version.__version__)
+    assert re.match(ptrn, edgegraph.__version__)


### PR DESCRIPTION
**Category**

This PR is a

* [x] Bugfix
  * [ ] Hotfix merging directly into `master`
* [ ] New feature
* [ ] Version release
* [ ] General code quality improvement
* [ ] Something else: (please describe)

**Description**

Version numbering constants are exposed at the module level now.

**Related issues**

Fixes #120.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
  * [ ] For release PRs, the changelog has been updated
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

