### PR TITLE
Replace _PyRLock with RLock; remove from pickling data

### DIFF
--- a/docs/usage/20-threadsafety.rst
+++ b/docs/usage/20-threadsafety.rst
@@ -55,11 +55,9 @@ For example, consider the following:
    you may often need to use reentrant locks (RLocks).
 
    In addition, if you intend to pickle objects containing RLocks, be aware
-   that it doesn't seem to work in conjunction with edgegraph's
-   :py:mod:`non-recursive pickler <edgegraph.output.nrpickler>`.  Internally,
-   edgegraph faces this very problem - and uses ``threading._PyRLock`` to work
-   around it.  It's not a good practice, but seems to be necessary.  See
-   https://github.com/mishaturnbull/edgegraph/issues/118.
+   that you need to remove them before pickling and re-add them afterwards.
+   See the :py:mod:`non-recursive pickler <edgegraph.output.nrpickler>` for
+   more information and references to examples.
 
 Async and Multiprocessing
 -------------------------

--- a/edgegraph/output/nrpickler.py
+++ b/edgegraph/output/nrpickler.py
@@ -52,6 +52,20 @@ Usage of this pickler should be similar to the built-in one::
 At this point, the ``unpacked`` object is a Universe identical in every way to
 ``graph``, except it is a different instance.  All of its vertices, links, and
 any attributes of have all been unpacked.
+
+.. note::
+
+   If you intend to pickle / unpickle objects which use
+   :py:class:`~threading.RLock`, you must implement special handling of
+   ``__getstate__`` and ``__setstate__`` (or equivalent) customization rules
+   which remove these locks before pickling and re-add them to your instance
+   after unpickling.  See https://github.com/mishaturnbull/edgegraph/issues/118
+   for some background on this and the associated PR for an example of what it
+   looks like (I suggest in particular the ``vertex.py`` changes as a good
+   example).
+
+   Ensure you call the superclass ``__getstate__`` and ``__setstate__`` from
+   yours!
 """
 
 import io

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import threading
 import uuid
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+
+from typing_extensions import TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from edgegraph.structure.universe import Universe
@@ -101,11 +102,13 @@ class BaseObject(object):
         # https://stackoverflow.com/a/17016257
         self._universes = [*dict.fromkeys(self._universes)]
 
+    @override
     def __getstate__(self) -> dict:
         data = self.__dict__.copy()
         data.pop("_universes_lock")
         return data
 
+    @override
     def __setstate(self, value: dict) -> None:
         self.__dict__.update(value)
         self.__dict__["_universes_lock"] = threading.RLock()

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -104,12 +104,30 @@ class BaseObject(object):
 
     @override
     def __getstate__(self) -> dict:
+        """
+        Get the state of this object for pickling to a binary stream.
+
+        This is part of the pickling protocol wherein objects are converted to
+        binary streams; ``__getstate__`` usage allows customization of which
+        attributes of this object are pickled and which aren't.  We use it here
+        to avoid pickling ``RLock`` objects, which are known to not properly
+        un-dill.  See https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
         data = self.__dict__.copy()
         data.pop("_universes_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
+        """
+        Set the state of this object as it's being unpickled.
+
+        This is part of the picling protocol wherein objects are given an
+        opportunity to control happenings as they're reinstantiated coming out
+        of the binary stream.  We use it here to re-apply ``RLock`` attributes,
+        which are known to not properly un-dill.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
         self.__dict__.update(value)
         self.__dict__["_universes_lock"] = threading.RLock()
 

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -109,7 +109,7 @@ class BaseObject(object):
         return data
 
     @override
-    def __setstate(self, value: dict) -> None:
+    def __setstate__(self, value: dict) -> None:
         self.__dict__.update(value)
         self.__dict__["_universes_lock"] = threading.RLock()
 

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -88,7 +88,7 @@ class BaseObject(object):
             for key, val in attributes.items():
                 setattr(self, key, val)
 
-        self._universes_lock = threading._PyRLock()
+        self._universes_lock = threading.RLock()
 
         #: Internal reference to the universes this object is a part of
         #:
@@ -100,6 +100,15 @@ class BaseObject(object):
         # deduplicate it while keeping order
         # https://stackoverflow.com/a/17016257
         self._universes = [*dict.fromkeys(self._universes)]
+
+    def __getstate__(self) -> dict:
+        data = self.__dict__.copy()
+        data.pop("_universes_lock")
+        return data
+
+    def __setstate(self, value: dict) -> None:
+        self.__dict__.update(value)
+        self.__dict__["_universes_lock"] = threading.RLock()
 
     @property
     def uid(self) -> int:

--- a/edgegraph/structure/base.py
+++ b/edgegraph/structure/base.py
@@ -117,7 +117,8 @@ class BaseObject(object):
         data.pop("_universes_lock")
         return data
 
-    @override
+    # Note: no @override here.  object() declares __getstate__, but not
+    # __setstate__!
     def __setstate__(self, value: dict) -> None:
         """
         Set the state of this object as it's being unpickled.

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -78,7 +78,7 @@ class Link(base.BaseObject):
         # would love to use regular threading.RLock() here, but it breaks
         # dill...
         # https://github.com/mishaturnbull/edgegraph/issues/118
-        self._verts_lock = threading._PyRLock()
+        self._verts_lock = threading.RLock()
 
         #: Vertices that this link links
         #:
@@ -89,6 +89,15 @@ class Link(base.BaseObject):
             if vertices is not None:
                 for vert in vertices:
                     self.add_vertex(vert)
+
+    def __getstate__(self) -> dict:
+        data = self.__dict__.copy()
+        data.pop("_verts_lock")
+        return data
+
+    def __setstate__(self, value: dict) -> None:
+        self.__dict__.update(value)
+        self.__dict__["_verts_lock"] = threading.RLock()
 
     @property
     def vertices(self) -> tuple[Vertex, ...]:

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -93,13 +93,33 @@ class Link(base.BaseObject):
 
     @override
     def __getstate__(self) -> dict:
+        """
+        Remove ``RLock`` attributes from this object during pickling.
+
+        ``RLock``s are known to not properly un-dill; we need to remove them
+        here as this object is being pickled.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
+        # let parent superclass also handle its RLocks as needed
         data = super().__getstate__()
+
         data.pop("_verts_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
+        """
+        Re-apply ``RLock`` attributes to this object during unpickling.
+
+        ``RLock``s are known to not work properly with dill when deserializing,
+        and we removed them when we got this object's state in __getstate__.
+        So, we need to re-add them here.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
+        # parent class also has some RLocks it needs to recreate; ensure it
+        # does so
         super().__setstate__(value)
+
         self.__dict__["_verts_lock"] = threading.RLock()
 
     @property

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -7,7 +7,8 @@ Holds the Link class.
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING
+
+from typing_extensions import TYPE_CHECKING, override
 
 from edgegraph.structure import base
 
@@ -90,11 +91,13 @@ class Link(base.BaseObject):
                 for vert in vertices:
                     self.add_vertex(vert)
 
+    @override
     def __getstate__(self) -> dict:
         data = self.__dict__.copy()
         data.pop("_verts_lock")
         return data
 
+    @override
     def __setstate__(self, value: dict) -> None:
         self.__dict__.update(value)
         self.__dict__["_verts_lock"] = threading.RLock()

--- a/edgegraph/structure/link.py
+++ b/edgegraph/structure/link.py
@@ -93,13 +93,13 @@ class Link(base.BaseObject):
 
     @override
     def __getstate__(self) -> dict:
-        data = self.__dict__.copy()
+        data = super().__getstate__()
         data.pop("_verts_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
-        self.__dict__.update(value)
+        super().__setstate__(value)
         self.__dict__["_verts_lock"] = threading.RLock()
 
     @property

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -7,7 +7,8 @@ Holds the Universe class.
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING
+
+from typing_extensions import TYPE_CHECKING, override
 
 from edgegraph.structure import vertex
 
@@ -64,11 +65,13 @@ class Universe(vertex.Vertex):
             for v in vertices:
                 self.add_vertex(v)
 
+    @override
     def __getstate__(self) -> dict:
         data = self.__dict__.copy()
         data.pop("_verts_lock")
         return data
 
+    @override
     def __setstate__(self, value: dict) -> None:
         self.__dict__.update(value)
         self.__dict__["_verts_lock"] = threading.RLock()

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -67,13 +67,13 @@ class Universe(vertex.Vertex):
 
     @override
     def __getstate__(self) -> dict:
-        data = self.__dict__.copy()
+        data = super().__getstate__()
         data.pop("_verts_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
-        self.__dict__.update(value)
+        super().__setstate__(value)
         self.__dict__["_verts_lock"] = threading.RLock()
 
     @property

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -56,13 +56,22 @@ class Universe(vertex.Vertex):
         """
         super().__init__(uid=uid, attributes=attributes)
 
-        self._verts_lock = threading._PyRLock()
+        self._verts_lock = threading.RLock()
 
         #: Internal set of vertices
         self._vertices: list[Vertex] = []
         if vertices is not None:
             for v in vertices:
                 self.add_vertex(v)
+
+    def __getstate__(self) -> dict:
+        data = self.__dict__.copy()
+        data.pop("_verts_lock")
+        return data
+
+    def __setstate__(self, value: dict) -> None:
+        self.__dict__.update(value)
+        self.__dict__["_verts_lock"] = threading.RLock()
 
     @property
     def vertices(self) -> list[vertex.Vertex]:

--- a/edgegraph/structure/universe.py
+++ b/edgegraph/structure/universe.py
@@ -67,13 +67,32 @@ class Universe(vertex.Vertex):
 
     @override
     def __getstate__(self) -> dict:
+        """
+        Remove ``RLock`` attributes from this object during pickling.
+
+        ``RLock``s are known to not properly deserialize when using dill;
+        remove them here as this object is being pickled.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
+        # let the superclass handle its RLocks too
         data = super().__getstate__()
+
         data.pop("_verts_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
+        """
+        Recreate ``RLock`` attributes during unpickling.
+
+        ``RLock``s are knwn to not work properly with dill when deserializing,
+        and we removed them when we got this object's state in __getstate__.
+        So, we need to re-add the here.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
+        # let the superclass recreate its RLocks too
         super().__setstate__(value)
+
         self.__dict__["_verts_lock"] = threading.RLock()
 
     @property

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -110,9 +110,6 @@ class Vertex(base.BaseObject):
         with self._CACHE_STATS_LOCK:
             self._CACHE_STATS.update({self.uid: [0, 0, 0, 0]})
 
-        # would love to use regular threading.RLock() here, but it breaks
-        # dill...
-        # https://github.com/mishaturnbull/edgegraph/issues/118
         self._links_lock = threading.RLock()
         self._qanb_cache_lock = threading.RLock()
 
@@ -135,14 +132,35 @@ class Vertex(base.BaseObject):
 
     @override
     def __getstate__(self) -> dict:
+        """
+        Remove ``RLock`` attributes from this object during pickling.
+
+        ``RLock``s are known to not properly un-dill; we need to remove them
+        here as this object is being pickled.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
+        # parent class has some RLocks it also needs to remove; let it handle
+        # those
         data = super().__getstate__()
+
         data.pop("_links_lock")
         data.pop("_qanb_cache_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
+        """
+        Re-apply ``RLock`` attributes to this object during unpickling.
+
+        ``RLock``s are known to not work properly with dill when deserializing,
+        and we removed them when we got this object's state in __getstate__.
+        So, we need to re-add them here.  See
+        https://github.com/mishaturnbull/edgegraph/issues/118 .
+        """
+        # parent class also has some RLocks it needs to recreate; ensure it
+        # does so
         super().__setstate__(value)
+
         self.__dict__["_links_lock"] = threading.RLock()
         self.__dict__["_qanb_cache_lock"] = threading.RLock()
 

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -135,14 +135,14 @@ class Vertex(base.BaseObject):
 
     @override
     def __getstate__(self) -> dict:
-        data = self.__dict__.copy()
+        data = super().__getstate__()
         data.pop("_links_lock")
         data.pop("_qanb_cache_lock")
         return data
 
     @override
     def __setstate__(self, value: dict) -> None:
-        self.__dict__.update(value)
+        super().__setstate__(value)
         self.__dict__["_links_lock"] = threading.RLock()
         self.__dict__["_qanb_cache_lock"] = threading.RLock()
 

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -38,7 +38,7 @@ class Vertex(base.BaseObject):
 
     # would love to use regular threading.RLock() here, but it breaks dill...
     # https://github.com/mishaturnbull/edgegraph/issues/118
-    _CACHE_STATS_LOCK = threading._PyRLock()
+    _CACHE_STATS_LOCK = threading.RLock()
 
     @classmethod
     def total_cache_stats(cls) -> str:
@@ -112,8 +112,8 @@ class Vertex(base.BaseObject):
         # would love to use regular threading.RLock() here, but it breaks
         # dill...
         # https://github.com/mishaturnbull/edgegraph/issues/118
-        self._links_lock = threading._PyRLock()
-        self._qanb_cache_lock = threading._PyRLock()
+        self._links_lock = threading.RLock()
+        self._qanb_cache_lock = threading.RLock()
 
         #: Links that this vertex is associated with
         #:
@@ -131,6 +131,17 @@ class Vertex(base.BaseObject):
 
         with self._qanb_cache_lock:
             self.__qa_nb_cache: dict[tuple[Any, ...], list[Vertex]] = {}
+
+    def __getstate__(self) -> dict:
+        data = self.__dict__.copy()
+        data.pop("_links_lock")
+        data.pop("_qanb_cache_lock")
+        return data
+
+    def __setstate__(self, value: dict) -> None:
+        self.__dict__.update(value)
+        self.__dict__['_links_lock'] = threading.RLock()
+        self.__dict__['_qanb_cache_lock'] = threading.RLock()
 
     def add_to_universe(self, universe: Universe) -> None:
         """

--- a/edgegraph/structure/vertex.py
+++ b/edgegraph/structure/vertex.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, ClassVar
+
+from typing_extensions import TYPE_CHECKING, Any, ClassVar, override
 
 from edgegraph.structure import base
 
@@ -132,16 +133,18 @@ class Vertex(base.BaseObject):
         with self._qanb_cache_lock:
             self.__qa_nb_cache: dict[tuple[Any, ...], list[Vertex]] = {}
 
+    @override
     def __getstate__(self) -> dict:
         data = self.__dict__.copy()
         data.pop("_links_lock")
         data.pop("_qanb_cache_lock")
         return data
 
+    @override
     def __setstate__(self, value: dict) -> None:
         self.__dict__.update(value)
-        self.__dict__['_links_lock'] = threading.RLock()
-        self.__dict__['_qanb_cache_lock'] = threading.RLock()
+        self.__dict__["_links_lock"] = threading.RLock()
+        self.__dict__["_qanb_cache_lock"] = threading.RLock()
 
     def add_to_universe(self, universe: Universe) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dynamic = ["version"]
 name = "edgegraph"
 requires-python = ">= 3.7"
 dependencies = [
-    "dill"
+    "dill",
+    "typing_extensions",
 ]
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/tests/integration/test_pickling.py
+++ b/tests/integration/test_pickling.py
@@ -331,6 +331,12 @@ def test_p_up_thread_safety(protocol, straightline_graph_1k_directed):
     """
     There are known issues around pickling and unpickling threading.RLock()
     with the dill module.  Ensure they do not affect Edgegraph's structure.
+
+    If you find that this test fails with a timeout, it is likely an indicator
+    that the bug in question has been hit and not a simple timing failure.
+    Investigate it instead of simply upping the timeout!  See
+    https://github.com/mishaturnbull/issues/118 and the issue(s) it references
+    for more information.
     """
     uni, verts = straightline_graph_1k_directed
     serial = nrpickler.dumps((uni, verts), protocol=protocol)
@@ -338,7 +344,9 @@ def test_p_up_thread_safety(protocol, straightline_graph_1k_directed):
 
     assert p1[0] is not uni, "Dill deserialized same object!"
 
-    assert len(p1[0].vertices) == len(verts)
-    assert p1[1][0].links is not None
-    assert len(p1[1][0].universes) == 1
-    assert p1[1][0] in p1[1][0].universes[0].vertices
+    assert len(p1[0].vertices) == len(verts), "Could not acquire _verts_lock"
+    assert p1[1][0].links is not None, "Could not acquire _links_lock"
+    assert len(p1[1][0].universes) == 1, "Could not acquire _universes_lock"
+    assert p1[1][0] in p1[1][0].universes[0].vertices, (
+        "Could not acquire _verts_lock"
+    )

--- a/tests/integration/test_pickling.py
+++ b/tests/integration/test_pickling.py
@@ -323,3 +323,22 @@ def test_up_with_dill(protocol, straightline_graph_1k_directed):
 
     for i in range(len(verts)):
         assert p1[1][i].i == verts[i].i, "dill deserialized wrong order!"
+
+
+@pytest.mark.timeout(1)
+@pytest.mark.parametrize("protocol", list(range(pickle.HIGHEST_PROTOCOL)))
+def test_p_up_thread_safety(protocol, straightline_graph_1k_directed):
+    """
+    There are known issues around pickling and unpickling threading.RLock()
+    with the dill module.  Ensure they do not affect Edgegraph's structure.
+    """
+    uni, verts = straightline_graph_1k_directed
+    serial = nrpickler.dumps((uni, verts), protocol=protocol)
+    p1 = dill.loads(serial)
+
+    assert p1[0] is not uni, "Dill deserialized same object!"
+
+    assert len(p1[0].vertices) == len(verts)
+    assert p1[1][0].links is not None
+    assert len(p1[1][0].universes) == 1
+    assert p1[1][0] in p1[1][0].universes[0].vertices

--- a/tests/integration/test_pickling.py
+++ b/tests/integration/test_pickling.py
@@ -325,7 +325,7 @@ def test_up_with_dill(protocol, straightline_graph_1k_directed):
         assert p1[1][i].i == verts[i].i, "dill deserialized wrong order!"
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(3)
 @pytest.mark.parametrize("protocol", list(range(pickle.HIGHEST_PROTOCOL)))
 def test_p_up_thread_safety(protocol, straightline_graph_1k_directed):
     """


### PR DESCRIPTION
**Category**

This PR is a

* [x] Bugfix
  * [ ] Hotfix merging directly into `master`
* [ ] New feature
* [ ] Version release
* [ ] General code quality improvement
* [ ] Something else: (please describe)

**Description**

Replaces `threading._PyRLock` usage with `threading.RLock`s.  These are removed from pickling data before pickling.

Credit to @i-am-grub for finding this and showing me the fix!

This also sneaks in [`typing_extensions`][1] as a dependency.  This module provides the `@override` decorator for Python versions prior to 3.12, which is needed for easily type-checking `__getstate__` and `__setstate__` methods on those versions.  It only advertises support for 3.9 and up (non-EOL'd versions), but appears to import and run fine on at least all versions that are currently tested in CI here.

[1]: https://typing-extensions.readthedocs.io/en/latest/#

**Related issues**

Closes #118.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
  * [ ] For release PRs, the changelog has been updated
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

No unit test updates are expected; internal state management change only.

