### PR TITLE
Pretty-print Vertex representation under unit test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,14 +20,20 @@ from .fixtures import *  # noqa: F403
 
 LOG = logging.getLogger(__name__)
 
+
 # monkey-patch Vertex to pretty-repr itself with the `i` attribute if
 # available, since so many unit tests use this pattern.  Makes for MUUUUCH
 # easier debugging; but I don't want to make this a global API feature of
 # Vertex -- so for the unittests only!
 def new_repr(inst):
-    if hasattr(inst, 'i') and isinstance(inst.i, int):
+    """
+    Monkey-patched __repr__ for Vertex to print `i` attribute.
+    """
+    if hasattr(inst, "i") and isinstance(inst.i, int):
         return f"<Vertex i={inst.i} @ {hex(id(inst))}>"
     return super(Vertex, inst).__repr__()
+
+
 Vertex.__repr__ = new_repr
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,16 @@ from .fixtures import *  # noqa: F403
 
 LOG = logging.getLogger(__name__)
 
+# monkey-patch Vertex to pretty-repr itself with the `i` attribute if
+# available, since so many unit tests use this pattern.  Makes for MUUUUCH
+# easier debugging; but I don't want to make this a global API feature of
+# Vertex -- so for the unittests only!
+def new_repr(inst):
+    if hasattr(inst, 'i') and isinstance(inst.i, int):
+        return f"<Vertex i={inst.i} @ {hex(id(inst))}>"
+    return super().__repr__(inst)
+Vertex.__repr__ = new_repr
+
 
 # https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-parametrize
 # use strings for the params ("cache" and "nocache") instead of raw booleans

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 def new_repr(inst):
     if hasattr(inst, 'i') and isinstance(inst.i, int):
         return f"<Vertex i={inst.i} @ {hex(id(inst))}>"
-    return super().__repr__(inst)
+    return super(Vertex, inst).__repr__()
 Vertex.__repr__ = new_repr
 
 


### PR DESCRIPTION
**Category**

This PR is a

* [ ] Bugfix
  * [ ] Hotfix merging directly into `master`
* [x] New feature
* [ ] Version release
* [ ] General code quality improvement
* [ ] Something else: (please describe)

**Description**

`tests/conftest.py`, the PyTest configuration file (kinda; just go with it) monkey-patches in a `__repr__` method on `Vertex` which represents Vertex objects slightly differently: if that instance has an attribute `i` which is an integer, the value of `i` is clearly included in the representation.  Otherwise, the regular `__repr__` is called.

**Related issues**

N/A; inspired while working on #136, but not directly related and there is no issue for this.

**Checklist**

* [x] Code changes are complete
* [x] Documentation updates are made as applicable
  * [ ] For release PRs, the changelog has been updated
* [x] Unit tests are updated as applicable
* [x] Target branch is correct (`master` for releases and hotfixes; `develop`
  for all else)

